### PR TITLE
Unifies read output type with other Paths

### DIFF
--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -289,7 +289,7 @@ function Base.readdir(fp::S3Path)
     end
 end
 
-Base.read(fp::S3Path) = s3_get(fp.config, fp.bucket, fp.key)
+Base.read(fp::S3Path) = Vector{UInt8}(s3_get(fp.config, fp.bucket, fp.key))
 
 function Base.write(fp::S3Path, content::Union{String, Vector{UInt8}})
     s3_put(fp.config, fp.bucket, fp.key, content)

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -90,6 +90,7 @@ function test_s3_sync(p::PathSet)
         write(p.foo / "test.txt", "New File")
         sync(p.foo, ps.qux / "foo/")
         @test exists(p.qux / "foo" / "test.txt")
+        @test read(p.qux / "foo" / "test.txt") == b"New File"
         @test read(p.qux / "foo" / "test.txt", String) == "New File"
         @test modified(p.qux / "foo" / "baz.txt") == baz_t
         @test modified(p.qux / "foo" / "test.txt") > baz_t
@@ -134,9 +135,11 @@ function test_s3_folders_and_files(ps::PathSet)
         mkdir(ps.root / "foobar/")
         write(ps.root / "foobar" / "car.txt", "I'm a different object")
 
+        @test read(ps.root / "foobar") == b"I'm an object"
         @test read(ps.root / "foobar", String) == "I'm an object"
         @test_throws ArgumentError readpath(ps.root / "foobar")
         @test readpath(ps.root / "foobar/") == [ps.root / "foobar" / "car.txt"]
+        @test read(ps.root / "foobar" / "car.txt", String) == "I'm a different object"
     end
 end
 


### PR DESCRIPTION
Makes `read` return a `Vector{UInt8}` to match SystemPaths.

Fixes https://github.com/JuliaCloud/AWSS3.jl/issues/51