### PR TITLE
Added AWSCore v0.7 to compat section

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
-AWSCore = "0.5, 0.6"
+AWSCore = "0.5, 0.6, 0.7"
 FilePathsBase = "0.6"
 julia = "1"
 


### PR DESCRIPTION
I am making changes to [`AWSCore.jl CR #88`](https://github.com/JuliaCloud/AWSCore.jl/pull/88), these are breaking changes and thus require a version bump of the package to `v0.7.0`.

`AWSS3.jl@0.6.X` has a `compat` on `0.5, 0.6`. This means that my CR targets an older version of `AWSS3.jl`, which happens to be `v0.5.0`.

`AWSS3.jl@0.5.X` has a testing [bug](https://github.com/JuliaCloud/AWSS3.jl/blob/v0.5.0/test/runtests.jl#L261) which has been "resolved" in [`AWSS3.jl@0.6.X`](https://github.com/JuliaCloud/AWSS3.jl/blob/v0.6.0/test/runtests.jl#L264)

For my `AWSCore.jl` changes to go in, we need to include `0.7` in the `compat` section.