### PR TITLE
Updated TravisCI build badge in README to point to the correct location

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AWS S3 Interface for Julia
 
-[![Build Status](https://travis-ci.org/samoconnor/AWSS3.jl.svg)](https://travis-ci.org/samoconnor/AWSS3.jl)
+[![Build Status](https://travis-ci.org/JuliaCloud/AWSS3.jl.svg?branch=master)](https://travis-ci.org/JuliaCloud/AWSS3.jl)
 
 [Documentation](https://juliacloud.github.io/AWSCore.jl/build/AWSS3.html)
 


### PR DESCRIPTION
The old badge was pointing to SamOConnors TravisCI page, however we have migrated to the JuliaCloud TravisCI at some point.

Resolves https://github.com/JuliaCloud/AWSS3.jl/issues/55