### PR TITLE
Fixed issue getting files from root S3 directory

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 authors = ["Sam O'Connor"]
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -78,6 +78,10 @@ function Base.getproperty(fp::S3Path, attr::Symbol)
     elseif attr === :bucket
         return split(fp.drive, "//")[2]
     elseif attr === :key
+        if isempty(fp.segments)
+            return ""
+        end
+
         return join(fp.segments, '/') * (fp.isdirectory ? "/" : "")
     else
         return getfield(fp, attr)


### PR DESCRIPTION
Resolves #60 

There is a bug with reading files from the root "directory" of an S3 bucket, where when we access the `:key` attribute we would always return back `/` as a prefix. Files cannot be prefixed with this character as it's invalid, and thus we would always return back nothing.

This CR resolves the issue by check if the `fp.segments` are empty, if so return an empty string. `fp.segments` are used for "subdirectories" on an S3 bucket, for instance in the hierarchy below the `segments` for `file.txt` would be `[subdir1, subdir2]`. 

```
bucket-name
|-- subdir1
|     |-- subdir2
|          |-- file.txt
```

I have included testing for both `readdir()` for both S3 and local storage testing. One thing to note with local testing is the difference between an `S3Path` and `AbstractPath`. An `S3Path` will suffix a directory with the `/` character, while an `AbstractPath` will not. This has led to a special case when testing, if anyone has any suggestions on how to improve this I'd love to hear them!

Another thing which I have noticed when using `sync()` if you have two directories consecutively named the same thing, the files in the second directory will not be transferred and you will encounter an error with the `sync()` call. I have logged an issue for this found here: #62 

I have also moved the empty testing buckets code to the end of testing, so that you do not always have 1 bucket of testing data living in S3. I also have logged an issue to refactor testing #61 and just kept the current format going here.