### PR TITLE
Extra S3Path Constructors

### DIFF
--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -64,7 +64,7 @@ function S3Path(
     return S3Path(
         key.segments,
         "/",
-        strip(startswith(bucket, "s3://") ? bucket : "s3://$bucket", '/'),
+        normalize_bucket_name(bucket),
         isdirectory,
         config,
     )
@@ -89,6 +89,10 @@ function S3Path(str::AbstractString; config::AWSConfig=aws_config())
     end
 
     return S3Path(path, root, drive, isdirectory, config)
+end
+
+function normalize_bucket_name(bucket)
+    return strip(startswith(bucket, "s3://") ? bucket : "s3://$bucket", '/')
 end
 
 Base.print(io::IO, fp::S3Path) = print(io, fp.anchor * fp.key)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -40,6 +40,36 @@ function S3Path()
     )
 end
 
+function S3Path(
+    bucket::AbstractString,
+    key::AbstractString;
+    isdirectory::Bool=false,
+    config::AWSConfig=aws_config(),
+)
+    return S3Path(
+        Tuple(filter!(!isempty, split(key, "/"))),
+        "/",
+        strip(startswith(bucket, "s3://") ? bucket : "s3://$bucket", '/'),
+        isdirectory,
+        config,
+    )
+end
+
+function S3Path(
+    bucket::AbstractString,
+    key::AbstractPath;
+    isdirectory::Bool=false,
+    config::AWSConfig=aws_config(),
+)
+    return S3Path(
+        key.segments,
+        "/",
+        strip(startswith(bucket, "s3://") ? bucket : "s3://$bucket", '/'),
+        isdirectory,
+        config,
+    )
+end
+
 function S3Path(str::AbstractString; config::AWSConfig=aws_config())
     str = String(str)
     startswith(str, "s3://") || throw(ArgumentError("$str doesn't start with s3://"))

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -14,6 +14,17 @@ ps = PathSet(
     false
 )
 
+function test_s3_constructors(ps::PathSet)
+    @test S3Path(bucket_name, "pathset-root/foo/baz.txt") == ps.baz
+    @test S3Path(bucket_name, p"pathset-root/foo/baz.txt") == ps.baz
+    @test S3Path(bucket_name, p"/pathset-root/foo/baz.txt") == ps.baz
+    @test S3Path("s3://$bucket_name", p"/pathset-root/foo/baz.txt") == ps.baz
+    @test S3Path(bucket_name, "pathset-root/bar/qux"; isdirectory=true) == ps.qux
+    @test S3Path(bucket_name, "pathset-root/bar/qux/"; isdirectory=true) == ps.qux
+    @test S3Path(bucket_name, p"pathset-root/bar/qux"; isdirectory=true) == ps.qux
+    @test S3Path(bucket_name, p"/pathset-root/bar/qux"; isdirectory=true) == ps.qux
+end
+
 function test_s3_join(ps::PathSet)
     @testset "join" begin
         @test join(ps.root, "bar/") == ps.bar
@@ -149,6 +160,7 @@ end
 @testset "$(typeof(ps.root))" begin
     testsets = [
         test_constructor,
+        test_s3_constructors,
         test_registration,
         test_show,
         test_parse,


### PR DESCRIPTION
In particular, if you explicitly want to construct an `S3Path` with a bucket, key and specify whether it's a directory. This should be more convenient than calling the rather low level default constructor or requiring some manual string manipulations.