### PR TITLE
Remove unused DataStructures dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.6.9"
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
@@ -20,7 +19,6 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
 AWSCore = "0.5, 0.6"
-DataStructures = "0.15, 0.16, 0.17"
 EzXML = "0.9"
 FilePathsBase = "0.6, 0.7"
 HTTP = "0.8"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -22,8 +22,6 @@ export S3Path, s3_arn, s3_put, s3_get, s3_get_file, s3_exists, s3_delete, s3_cop
        s3_complete_multipart_upload, s3_multipart_upload,
        s3_get_tags, s3_put_tags, s3_delete_tags
 
-import DataStructures: OrderedDict
-
 using AWSCore
 using FilePathsBase
 using HTTP


### PR DESCRIPTION
I was going to switch DataStructures to OrderedCollections when I realized that `OrderedDict` isn't even used in this package.