### PR TITLE
Fixed S3 Multi-Part Upload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 authors = ["Sam O'Connor"]
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
@@ -18,7 +18,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
-AWSCore = "0.5, 0.6"
+AWSCore = "0.6.11"
 EzXML = "0.9, 1"
 FilePathsBase = "0.6, 0.7, 0.8"
 HTTP = "0.8"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -59,7 +59,8 @@ function s3(aws::AWSConfig,
             version="",
             content="",
             return_stream=false,
-            return_raw=false,)
+            return_raw=false,
+            return_headers=false)
 
     # Build query string...
     if version != ""
@@ -106,7 +107,7 @@ function s3(aws::AWSConfig,
         end
         request[:url] = url
 
-        response = AWSCore.do_request(request)
+        response = AWSCore.do_request(request; return_headers=return_headers)
 
         # Handle 301 Moved Permanently with missing Location header.
         # https://github.com/samoconnor/AWSS3.jl/issues/25
@@ -119,7 +120,7 @@ function s3(aws::AWSConfig,
             end
             request[:url] = string(get(aws, :protocol, "https"), "://",
                                    response["Endpoint"], resource)
-            response = AWSCore.do_request(request)
+            response = AWSCore.do_request(request; return_headers=return_headers)
         end
 
         return response
@@ -686,13 +687,14 @@ end
 
 function s3_upload_part(aws::AWSConfig, upload, part_number, part_data)
 
-    response = s3(aws, "PUT", upload["Bucket"];
+    _, headers = s3(aws, "PUT", upload["Bucket"];
                   path = upload["Key"],
                   query = Dict("partNumber" => part_number,
                                "uploadId" => upload["UploadId"]),
-                  content = part_data)
+                  content = part_data,
+                  return_headers = true)
 
-    response.headers["ETag"]
+    return Dict(headers)["ETag"]
 end
 
 
@@ -712,7 +714,7 @@ function s3_complete_multipart_upload(aws::AWSConfig,
                   query = Dict("uploadId" => upload["UploadId"]),
                   content = string(doc))
 
-    response
+    return response
 end
 
 

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -107,7 +107,11 @@ function s3(aws::AWSConfig,
         end
         request[:url] = url
 
-        response = AWSCore.do_request(request; return_headers=return_headers)
+        if return_headers
+            response, headers = AWSCore.do_request(request; return_headers=return_headers)
+        else
+            response = AWSCore.do_request(request; return_headers=return_headers)
+        end
 
         # Handle 301 Moved Permanently with missing Location header.
         # https://github.com/samoconnor/AWSS3.jl/issues/25
@@ -120,10 +124,10 @@ function s3(aws::AWSConfig,
             end
             request[:url] = string(get(aws, :protocol, "https"), "://",
                                    response["Endpoint"], resource)
-            response = AWSCore.do_request(request; return_headers=return_headers)
+            return AWSCore.do_request(request; return_headers=return_headers)
         end
 
-        return response
+        return (return_headers ? (response, headers) : response)
 
     catch e
 

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -161,6 +161,20 @@ end
     end
 end
 
+@testset "Multi-Part Upload" begin
+    MIN_S3_CHUNK_SIZE = 5 * 1024 * 1024 # 5 MB
+    key_name = "multi-part-key"
+    upload = s3_begin_multipart_upload(aws, bucket_name, key_name)
+    tags = Vector{String}()
+
+    for part_number in 1:5
+        push!(tags, s3_upload_part(aws, upload, part_number, rand(UInt8, MIN_S3_CHUNK_SIZE)))
+    end
+
+    s3_complete_multipart_upload(aws, upload, tags)
+    @test s3_exists(bucket_name, key_name)
+end
+
 @testset "Empty and Delete Bucket" begin
     for b in s3_list_buckets()
         if occursin(r"^ocaws.jl.test", b)


### PR DESCRIPTION
**Depends On:** https://github.com/JuliaCloud/AWSCore.jl/pull/117
**Resolves:** #84 

## Overview
Previously `AWSCore.jl` was not returning headers for a request and the `s3_upload_part()` would break. Changes have been made in that package to return response headers when the kwarg `return_headers=true` is passed in.

This merge request is just updating the `s3_upload_part()` to properly pull the returned `ETag` from Amazon, as well as include a test for multi-part uploading.