### PR TITLE
Update to the latest version of FilePathsBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 authors = ["Sam O'Connor"]
-version = "0.6.12"
+version = "0.7.0"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
@@ -10,7 +10,6 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
 Retry = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
 SymDict = "2da68c74-98d7-5633-99d6-8493888d7b1e"
@@ -20,7 +19,7 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 [compat]
 AWSCore = "0.6.11"
 EzXML = "0.9, 1"
-FilePathsBase = "0.6, 0.7, 0.8"
+FilePathsBase = "0.9"
 HTTP = "0.8"
 MbedTLS = "0.6, 0.7, 1"
 Retry = "0.3, 0.4"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -24,6 +24,7 @@ export S3Path, s3_arn, s3_put, s3_get, s3_get_file, s3_exists, s3_delete, s3_cop
 
 using AWSCore
 using FilePathsBase
+using FilePathsBase: /, join
 using HTTP
 using SymDict
 using Retry

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,8 @@ using AWSCore
 using Retry
 using HTTP
 using FilePathsBase
+using FilePathsBase: /, join
 using FilePathsBase.TestPaths
-using LinearAlgebra  # for norm S3Path tests
 using UUIDs: uuid4
 
 AWSCore.set_debug_level(0)


### PR DESCRIPTION
- `tryparse` instead of `ispathtype/constructor`.
- Breaking improvements to `parent(s)` functions
- `/` and `join` need to be explicitly imported from FilePathsBase and don't extend Base
- Function renames that aren't explicitly implemented for S3Path, but required updating tests