### PR TITLE
Wait for entries to be available in `isdir` objects channel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 authors = ["Sam O'Connor"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -174,7 +174,12 @@ function Base.isdir(fp::S3Path)
     end
 
     objects = s3_list_objects(fp.config, fp.bucket, key; max_items=1)
-    return !isempty(objects)
+
+    # `objects` is a `Channel`, so we call iterate to see if there are any objects that
+    # match our directory key.
+    # NOTE: `iterate` should handle waiting on a value to become available or return `nothing`
+    # if the channel is closed without inserting anything.
+    return iterate(objects) !== nothing
 end
 
 function Base.stat(fp::S3Path)


### PR DESCRIPTION
The tests were failing locally on julia 1.5, but the CI hadn't run for a month. As a result, this is just a 1 line change with some comments explaining why we're using `iterate`.