### PR TITLE
s3_get_file proxy patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 authors = ["Sam O'Connor"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 authors = ["Sam O'Connor"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -186,7 +186,8 @@ function s3_get_file(aws::AWSConfig, bucket, path, filename; version="", kwargs.
 
     stream = s3(aws, "GET", bucket; path = path,
                                     version = version,
-                                    return_stream = true)
+                                    return_stream = true,
+                                    kwargs...)
 
     open(filename, "w") do file
         while !eof(stream)


### PR DESCRIPTION
Missed passing the `kwargs` (read proxy) along in one higher function definition.