### PR TITLE
Define Z as a literal in Date.format

### DIFF
--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -760,7 +760,7 @@ function _s3_sign_url_v4(
     path = HTTP.escapepath("/$bucket/$path")
 
     now_datetime = now(Dates.UTC)
-    datetime_stamp = Dates.format(now_datetime, "YYYYmmddTHHMMSSZ")
+    datetime_stamp = Dates.format(now_datetime, "YYYYmmddTHHMMSS\\Z")
     date_stamp = Dates.format(now_datetime, "YYYYmmdd")
 
     service = "s3"


### PR DESCRIPTION
Closes #113 

Simple way to recreate issue:
```
(@v1.5) pkg> activate --temp
 Activating new environment at `/var/folders/2b/t1353wm927b6zp7cf5zjhs_c0000gn/T/jl_zHqfFI/Project.toml`

(jl_zHqfFI) pkg> add AWSS3

julia> using AWSS3, Dates

julia> now_datetime = now(Dates.UTC)
2020-11-24T01:44:22.415

julia> datetime_stamp = Dates.format(now_datetime, "YYYYmmddTHHMMSSZ")
"20201124T014422Z"

(jl_zHqfFI) pkg> add TimeZones

julia> using TimeZones

julia> datetime_stamp = Dates.format(now_datetime, "YYYYmmddTHHMMSSZ")
ERROR: type DateTime has no field zone
Stacktrace:
 [1] getproperty(::DateTime, ::Symbol) at ./Base.jl:33
 [2] format(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Dates.DatePart{'Z'}, ::DateTime, ::Dates.DateLocale) at /Users/maryjoramos/.julia/packages/TimeZones/CNOFt/src/parse.jl:81
 [3] macro expansion at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Dates/src/io.jl:531 [inlined]
 [4] format(::Base.GenericIOBuffer{Array{UInt8,1}}, ::DateTime, ::DateFormat{:YYYYmmddTHHMMSSZ,Tuple{Dates.DatePart{'Y'},Dates.DatePart{'m'},Dates.DatePart{'d'},Dates.Delim{Char,1},Dates.DatePart{'H'},Dates.DatePart{'M'},Dates.DatePart{'S'},Dates.DatePart{'Z'}}}) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Dates/src/io.jl:526
 [5] format(::DateTime, ::DateFormat{:YYYYmmddTHHMMSSZ,Tuple{Dates.DatePart{'Y'},Dates.DatePart{'m'},Dates.DatePart{'d'},Dates.Delim{Char,1},Dates.DatePart{'H'},Dates.DatePart{'M'},Dates.DatePart{'S'},Dates.DatePart{'Z'}}}, ::Int64) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Dates/src/io.jl:538
 [6] format(::DateTime, ::DateFormat{:YYYYmmddTHHMMSSZ,Tuple{Dates.DatePart{'Y'},Dates.DatePart{'m'},Dates.DatePart{'d'},Dates.Delim{Char,1},Dates.DatePart{'H'},Dates.DatePart{'M'},Dates.DatePart{'S'},Dates.DatePart{'Z'}}}) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Dates/src/io.jl:537
 [7] format(::DateTime, ::String; locale::Dates.DateLocale) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Dates/src/io.jl:577
 [8] format(::DateTime, ::String) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Dates/src/io.jl:577
 [9] top-level scope at REPL[10]:1
```

When TimeZones [Dates.format](https://github.com/JuliaTime/TimeZones.jl/blob/master/src/parse.jl#L80) is in scope, `datetime_stamp = Dates.format(now_datetime, "YYYYmmddTHHMMSSZ")` will dispatch to that version because of the `Z`.  However, we want to format a `DateTime` not a `ZonedDateTime`. 

In order to avoid dispatching to TimeZones [Dates.format](https://github.com/JuliaTime/TimeZones.jl/blob/master/src/parse.jl#L80), we can escape the `Z`.

Continuing from the example above:
```
julia> datetime_stamp = Dates.format(now_datetime, "YYYYmmddTHHMMSS\\Z")
"20201124T014422Z"
```