### PR TITLE
Cleanup the test CI buckets

### DIFF
--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -824,6 +824,21 @@ end
 s3_sign_url(a...;b...) = s3_sign_url(global_aws_config(), a...;b...)
 
 
+"""
+    s3_nuke_bucket(bucket_name)
+
+This function is NOT exported on purpose.
+It will delete all versions of objects in the given bucket and then the bucket itself.
+"""
+function s3_nuke_bucket(aws::AWSConfig, bucket_name)
+    for v in s3_list_versions(aws, bucket_name)
+        s3_delete(aws, bucket_name, v["Key"]; version = v["VersionId"])
+    end
+
+    s3_delete_bucket(aws, bucket_name)
+end
+
+
 include("s3path.jl")
 
 end #module AWSS3

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -827,8 +827,11 @@ s3_sign_url(a...;b...) = s3_sign_url(global_aws_config(), a...;b...)
 """
     s3_nuke_bucket(bucket_name)
 
-This function is NOT exported on purpose.
-It will delete all versions of objects in the given bucket and then the bucket itself.
+This function is NOT exported on purpose. AWS does not officially support this type of action,
+although it is a very nice utility one this is not exported just as a safe measure against
+accidentally blowing up your bucket.
+
+*Warning: It will delete all versions of objects in the given bucket and then the bucket itself.*
 """
 function s3_nuke_bucket(aws::AWSConfig, bucket_name)
     for v in s3_list_versions(aws, bucket_name)

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -181,7 +181,8 @@ end
 end
 
 @testset "Empty and Delete Bucket" begin
-    s3_nuke_bucket(bucket_name)
+    AWSS3.s3_nuke_bucket(aws, bucket_name)
+    @test !in(bucket_name, s3_list_buckets(aws))
 end
 
 @testset "Delete Non-Existant Bucket" begin

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -1,4 +1,3 @@
-aws = AWS.global_aws_config()
 aws.region = "us-east-1"
 bucket_name = "ocaws.jl.test." * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ"))
 
@@ -182,12 +181,7 @@ end
 end
 
 @testset "Empty and Delete Bucket" begin
-    for v in s3_list_versions(aws, bucket_name)
-        s3_delete(aws, bucket_name, v["Key"]; version = v["VersionId"])
-    end
-
-    s3_delete_bucket(aws, bucket_name)
-    @test !in(bucket_name, s3_list_buckets(aws))
+    s3_nuke_bucket(bucket_name)
 end
 
 @testset "Delete Non-Existant Bucket" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,16 @@ using FilePathsBase: /, join
 using FilePathsBase.TestPaths
 using UUIDs: uuid4
 
+aws = AWSConfig()
+
+function s3_nuke_bucket(bucket_name)
+    for v in s3_list_versions(aws, bucket_name)
+        s3_delete(aws, bucket_name, v["Key"]; version = v["VersionId"])
+    end
+
+    s3_delete_bucket(aws, bucket_name)
+end
+
 @testset "AWSS3.jl" begin
     include("s3path.jl")
     include("awss3.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,14 +12,6 @@ using UUIDs: uuid4
 
 aws = AWSConfig()
 
-function s3_nuke_bucket(bucket_name)
-    for v in s3_list_versions(aws, bucket_name)
-        s3_delete(aws, bucket_name, v["Key"]; version = v["VersionId"])
-    end
-
-    s3_delete_bucket(aws, bucket_name)
-end
-
 @testset "AWSS3.jl" begin
     include("s3path.jl")
     include("awss3.jl")

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -314,3 +314,5 @@ end
         @test p"s3://foo/bar" / "baz/" == p"s3://foo/bar/baz/"
     end
 end
+
+s3_nuke_bucket(bucket_name)

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -315,4 +315,4 @@ end
     end
 end
 
-s3_nuke_bucket(bucket_name)
+AWSS3.s3_nuke_bucket(aws, bucket_name)


### PR DESCRIPTION
For some reason buckets were not being cleaned up after the CI from the `S3Path` testing. I emptied and deleted all of these testing buckets.

These changes will now properly clean up after themselves. I'm not sure if we want to implement the `s3_nuke_bucket` as an exported function and give people the power explicitly.