### PR TITLE
allow mkdir(p"s3://path/not/ending/in/slash")

### DIFF
--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -214,7 +214,7 @@ Base.iswritable(fp::S3Path) = true
 Base.ismount(fp::S3Path) = false
 
 function Base.mkdir(fp::S3Path; recursive=false, exist_ok=false)
-    fp.isdirectory || throw(ArgumentError("S3Path folders must end with '/': $fp"))
+    fp = fp.isdirectory ? fp : S3Path(fp.segments, fp.root, fp.drive, true, fp.config)
 
     if exists(fp)
         !exist_ok && error("$fp already exists.")

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -63,6 +63,11 @@ function test_s3_mkdir(p::PathSet)
         @test exists(garply)
         rm(p.root / "corge/"; recursive=true)
         @test !exists(garply)
+        garply_noslash = p.root / "corge" / "grault" / "garply"
+        mkdir(garply_noslash; recursive=true)
+        @test exists(garply)
+        rm(p.root / "corge/"; recursive=true)
+        @test !exists(garply)
     end
 end
 


### PR DESCRIPTION
aligning with `Base.mkdir` behavior.