### PR TITLE
write defaults to multipart for large files.

### DIFF
--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -349,7 +349,7 @@ function Base.write(fp::S3Path, content::Vector{UInt8}; part_size_mb=50, multipa
         return s3_put(fp.config, fp.bucket, fp.key, content)
     else
         io = IOBuffer(content)
-        return s3_multipart_upload(fp.config, fp.bucket, fp.key, io, part_size_mb=part_size_mb; other_kwargs...)
+        return s3_multipart_upload(fp.config, fp.bucket, fp.key, io, part_size_mb; other_kwargs...)
     end
 end
 

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -342,7 +342,7 @@ Base.read(fp::S3Path) = Vector{UInt8}(s3_get(fp.config, fp.bucket, fp.key))
 
 Base.write(fp::S3Path, content::String; kwargs...) = Base.write(fp, Vector{UInt8}(content); kwargs...)
 
-function Base.write(fp::S3Path, content::Vector{UInt8}; part_size_mb=50, multipart::Bool=false, other_kwargs...)
+function Base.write(fp::S3Path, content::Vector{UInt8}; part_size_mb=50, multipart::Bool=true, other_kwargs...)
     # avoid HTTPClientError('An HTTP Client raised an unhandled exception: string longer than 2147483647 bytes')
     MAX_HTTP_BYTES = 2147483647
     if !multipart || length(content) < MAX_HTTP_BYTES

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -174,7 +174,7 @@ end
 function test_large_write(ps::PathSet)
     teststr = repeat("This is a test string!", round(Int, 2e5));
     @testset "large write/read" begin
-        write(ps.quux, teststr; part_size=1, multipart=true)
+        write(ps.quux, teststr; part_size_mb=1, multipart=true)
         @test read(ps.quux, String) == teststr
     end
 end


### PR DESCRIPTION
To align with Base.write

(shoulda made this the default in #118 my bad)