### PR TITLE
support for `AbstractAWSConfig`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
-AWS = "1"
+AWS = "1.25"
 EzXML = "0.9, 1"
 FilePathsBase = "0.9"
 HTTP = "0.8, 0.9"

--- a/README.md
+++ b/README.md
@@ -19,3 +19,44 @@ s3_enable_versioning(aws, "my.bucket")
 s3_put(aws, "my.bucket", "key", "Hello!")
 println(s3_get(aws, "my.bucket", "key"))
 ```
+
+## `S3Path`
+This package exports the `S3Path` object.  This is an `AbstractPath` object as defined by
+[FilePathsBase.jl](https://github.com/rofinn/FilePathsBase.jl), allowing users to use
+Julia's `Base` [file system interface](https://docs.julialang.org/en/v1/base/file/) to
+obtain information from S3 buckets.  See the below example.
+```julia
+julia> using AWSS3, AWS, FilePathsBase;
+
+# global_aws_config() is also the default if no `config` argument is passed
+julia> p = S3Path("s3://bucket-name/dir1/", config=global_aws_config());
+
+julia> readdir(p)
+1-element Vector{SubString{String}}:
+ "demo.txt"
+
+julia> file = joinpath(p, "demo.txt")
+p"s3://bucket-name/dir1/demo.txt"
+
+julia> stat(file)
+Status(
+  device = 0,
+  inode = 0,
+  mode = -rw-rw-rw-,
+  nlink = 0,
+  uid = 1000 (username),
+  gid = 1000 (username),
+  rdev = 0,
+  size = 34 (34.0),
+  blksize = 4096 (4.0K),
+  blocks = 1,
+  mtime = 2021-01-30T18:53:02,
+  ctime = 2021-01-30T18:53:02,
+)
+
+julia> String(read(file))  # fetch the file into memory
+"this is a file for testing S3Path\n"
+
+julia> rm(file)  # delete the file
+UInt8[]
+```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This package exports the `S3Path` object.  This is an `AbstractPath` object as d
 [FilePathsBase.jl](https://github.com/rofinn/FilePathsBase.jl), allowing users to use
 Julia's `Base` [file system interface](https://docs.julialang.org/en/v1/base/file/) to
 obtain information from S3 buckets.  See the below example.
+
 ```julia
 julia> using AWSS3, AWS, FilePathsBase;
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ println(s3_get(aws, "my.bucket", "key"))
 ```
 
 ## `S3Path`
-This package exports the `S3Path` object.  This is an `AbstractPath` object as defined by
-[FilePathsBase.jl](https://github.com/rofinn/FilePathsBase.jl), allowing users to use
+This package exports the `S3Path` object. 
+This is an `AbstractPath` object as defined by [FilePathsBase.jl](https://github.com/rofinn/FilePathsBase.jl), allowing users to use
 Julia's `Base` [file system interface](https://docs.julialang.org/en/v1/base/file/) to
-obtain information from S3 buckets.  See the below example.
+obtain information from S3 buckets.
+See the below example.
 
 ```julia
 julia> using AWSS3, AWS, FilePathsBase;

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -4,20 +4,9 @@ struct S3Path{A<:AbstractAWSConfig} <: AbstractPath
     drive::String
     isdirectory::Bool
     config::A
-
-    # this method ensures that there is proper conversion to Tuple{Vararg{String}} for first arg,
-    # which can be a little temperamental if you don't explicitly handle it
-    function S3Path{A}(
-        segments,
-        root::AbstractString,
-        drive::AbstractString,
-        isdirectory::Bool,
-        config::A
-    ) where {A<:AbstractAWSConfig}
-        new{typeof(config)}(tuple((String(s) for s in segments)...), root, drive, isdirectory, config)
-    end
 end
 
+# constructor that converts but does not require type parameter
 function S3Path(segments, root::AbstractString, drive::AbstractString, isdirectory::Bool,
                 config::AbstractAWSConfig)
     S3Path{typeof(config)}(segments, root, drive, isdirectory, config)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -5,10 +5,17 @@ struct S3Path{A<:AbstractAWSConfig} <: AbstractPath
     isdirectory::Bool
     config::A
 
-    function S3Path(segments, root::AbstractString, drive::AbstractString, isdirectory::Bool,
-                    config::AbstractAWSConfig)
+    # this method ensures that there is proper conversion to Tuple{Vararg{String}} for first arg,
+    # which can be a little tempremental if you don't explicitly handle it
+    function S3Path{A}(segments, root::AbstractString, drive::AbstractString, isdirectory::Bool,
+                       config::A) where {A<:AbstractAWSConfig}
         new{typeof(config)}(tuple((String(s) for s ∈ segments)...), root, drive, isdirectory, config)
     end
+end
+
+function S3Path(segments, root::AbstractString, drive::AbstractString, isdirectory::Bool,
+                config::AbstractAWSConfig)
+    S3Path{typeof(config)}(segments, root, drive, isdirectory, config)
 end
 
 """
@@ -44,6 +51,8 @@ function S3Path()
         config,
     )
 end
+# below definition needed by FilePathsBase
+S3Path{A}() where {A<:AbstractAWSConfig} = S3Path()
 
 function S3Path(
     bucket::AbstractString,

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -1,14 +1,14 @@
-struct S3Path <: AbstractPath
+struct S3Path{A<:AbstractAWSConfig} <: AbstractPath
     segments::Tuple{Vararg{String}}
     root::String
     drive::String
     isdirectory::Bool
-    config::AWSConfig
+    config::A
 end
 
 """
     S3Path()
-    S3Path(str; config::AWSConfig=aws_config())
+    S3Path(str; config::AbstractAWSConfig=aws_config())
 
 Construct a new AWS S3 path type which should be of the form
 "s3://<bucket>/prefix/to/my/object".
@@ -44,7 +44,7 @@ function S3Path(
     bucket::AbstractString,
     key::AbstractString;
     isdirectory::Bool=false,
-    config::AWSConfig=global_aws_config(),
+    config::AbstractAWSConfig=global_aws_config(),
 )
     return S3Path(
         Tuple(filter!(!isempty, split(key, "/"))),
@@ -59,7 +59,7 @@ function S3Path(
     bucket::AbstractString,
     key::AbstractPath;
     isdirectory::Bool=false,
-    config::AWSConfig=global_aws_config(),
+    config::AbstractAWSConfig=global_aws_config(),
 )
     return S3Path(
         key.segments,
@@ -71,13 +71,13 @@ function S3Path(
 end
 
 # To avoid a breaking change.
-function S3Path(str::AbstractString; config::AWSConfig=global_aws_config())
+function S3Path(str::AbstractString; config::AbstractAWSConfig=global_aws_config())
     result = tryparse(S3Path, str; config=config)
     result !== nothing || throw(ArgumentError("Invalid s3 path string: $str"))
     return result
 end
 
-function Base.tryparse(::Type{S3Path}, str::AbstractString; config::AWSConfig=global_aws_config())
+function Base.tryparse(::Type{S3Path}, str::AbstractString; config::AbstractAWSConfig=global_aws_config())
     str = String(str)
     startswith(str, "s3://") || return nothing
     root = ""

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -6,7 +6,7 @@ struct S3Path{A<:AbstractAWSConfig} <: AbstractPath
     config::A
 
     # this method ensures that there is proper conversion to Tuple{Vararg{String}} for first arg,
-    # which can be a little tempremental if you don't explicitly handle it
+    # which can be a little temperamental if you don't explicitly handle it
     function S3Path{A}(
         segments,
         root::AbstractString,

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -14,7 +14,7 @@ struct S3Path{A<:AbstractAWSConfig} <: AbstractPath
         isdirectory::Bool,
         config::A
     ) where {A<:AbstractAWSConfig}
-        new{typeof(config)}(tuple((String(s) for s ∈ segments)...), root, drive, isdirectory, config)
+        new{typeof(config)}(tuple((String(s) for s in segments)...), root, drive, isdirectory, config)
     end
 end
 

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -87,7 +87,7 @@ function Base.tryparse(::Type{S3Path}, str::AbstractString; config::Union{Nothin
     str = String(str)
     startswith(str, "s3://") || return nothing
     # we do this here so that the `@p_str` macro only tries to call AWS if it actually has an S3 path
-    isnothing(config) && (config = global_aws_config())
+    (config ≡ nothing) && (config = global_aws_config())
     root = ""
     path = ()
     isdirectory = true

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -7,8 +7,13 @@ struct S3Path{A<:AbstractAWSConfig} <: AbstractPath
 
     # this method ensures that there is proper conversion to Tuple{Vararg{String}} for first arg,
     # which can be a little tempremental if you don't explicitly handle it
-    function S3Path{A}(segments, root::AbstractString, drive::AbstractString, isdirectory::Bool,
-                       config::A) where {A<:AbstractAWSConfig}
+    function S3Path{A}(
+        segments,
+        root::AbstractString,
+        drive::AbstractString,
+        isdirectory::Bool,
+        config::A
+    ) where {A<:AbstractAWSConfig}
         new{typeof(config)}(tuple((String(s) for s ∈ segments)...), root, drive, isdirectory, config)
     end
 end

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -83,7 +83,7 @@ function S3Path(str::AbstractString; config::AbstractAWSConfig=global_aws_config
 end
 
 # if config=nothing, will not try to talk to AWS until after string is confirmed to be an s3 path
-function Base.tryparse(::Type{S3Path}, str::AbstractString; config::Union{Nothing,AbstractAWSConfig}=nothing)
+function Base.tryparse(::Type{<:S3Path}, str::AbstractString; config::Union{Nothing,AbstractAWSConfig}=nothing)
     str = String(str)
     startswith(str, "s3://") || return nothing
     # we do this here so that the `@p_str` macro only tries to call AWS if it actually has an S3 path


### PR DESCRIPTION
This adds support for `AbstractAWSConfig` (see [here](https://github.com/JuliaCloud/AWS.jl/pull/274)) and adds some minimal documentation of `S3Path` to the README.  The changes here are minimal: `AWSConfig` arguments are generalized to `AbstractAWSConfig` and `S3Path` now accepts a single type parameter which is the type of the config.

Note that currently there is a limitation in `FilePathsBase` that prevents types with parameters from being used as paths.  That issue is fixed [here](https://github.com/rofinn/FilePathsBase.jl/pull/111).  `S3Path` will not work properly until that is merged and tagged (it's a very small change so I'm hoping that can happen quite soon).