### PR TITLE
Fix `read(::S3Path)` for e.g. JSON

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
@@ -21,6 +21,7 @@ AWS = "1.25"
 EzXML = "0.9, 1"
 FilePathsBase = "0.9"
 HTTP = "0.8, 0.9"
+JSON3 = "1"
 MbedTLS = "0.6, 0.7, 1"
 OrderedCollections = "1"
 Retry = "0.3, 0.4"
@@ -29,7 +30,8 @@ XMLDict = "0.3, 0.4"
 julia = "1"
 
 [extras]
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "JSON3"]

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -527,7 +527,7 @@ end
 s3_purge_versions(a...; b...) = s3_purge_versions(global_aws_config(), a...; b...)
 
 """
-    s3_put([::AbstractAWSConfig], bucket, path, data; <keyword arguments>)
+    s3_put([::AbstractAWSConfig], bucket, path, data, data_type="", encoding=""; <keyword arguments>)
 
 [PUT Object](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html)
 `data` at `path` in `bucket`.

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -355,7 +355,7 @@ function Base.readdir(fp::S3Path; join=false, sort=true)
     end
 end
 
-Base.read(fp::S3Path) = Vector{UInt8}(s3_get(fp.config, fp.bucket, fp.key))
+Base.read(fp::S3Path) = Vector{UInt8}(s3_get(fp.config, fp.bucket, fp.key; raw=true))
 
 Base.write(fp::S3Path, content::String; kwargs...) = Base.write(fp, Vector{UInt8}(content); kwargs...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using FilePathsBase
 using FilePathsBase: /, join
 using FilePathsBase.TestPaths
 using UUIDs: uuid4
+using JSON3
 
 aws = AWSConfig()
 

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -337,6 +337,9 @@ end
 @testset "JSON roundtripping" begin
     json_path = S3Path("s3://$(bucket_name)/test_json"; config=aws)
     my_dict = Dict("key" => "value", "key2" => 5.0)
+    # here we use the "application/json" MIME type to trigger the heuristic parsing into a `LittleDict`
+    # that will hit a `MethodError` at the `Vector{UInt8}` constructor of `read(::S3Path)` if `raw=true`
+    # was not passed to `s3_get` in that method.
     s3_put(aws, bucket_name, "test_json", JSON3.write(my_dict), "application/json")
     json_bytes = read(json_path)
     @test JSON3.read(json_bytes, Dict) == my_dict

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -334,4 +334,13 @@ end
     end
 end
 
+@testset "JSON roundtripping" begin
+    json_path = S3Path("s3://$(bucket_name)/test_json"; config=aws)
+    my_dict = Dict("key" => "value", "key2" => 5.0)
+    s3_put(aws, bucket_name, "test_json", JSON3.write(my_dict), "application/json")
+    json_bytes = read(json_path)
+    @test JSON3.read(json_bytes, Dict) == my_dict
+    rm(json_path)
+end
+
 AWSS3.s3_nuke_bucket(aws, bucket_name)


### PR DESCRIPTION
fixes #138 

This was defined as
```julia
Base.read(fp::S3Path) = Vector{UInt8}(s3_get(fp.config, fp.bucket, fp.key))
```
which fails whenever `s3_get` does not return something that can pass to `Vector{UInt8}`, e.g. a LittleDict. Here we add `raw=true` to fix this.

Co-authored by @hannahilea