### PR TITLE
greatly improve `readdir` perf; fix bug

### DIFF
--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -342,25 +342,23 @@ function _pair_or_dict_get(p::Pair, k)
 end
 _pair_or_dict_get(d::AbstractDict, k) = get(d, k, nothing)
 
-function _readdir_add_results!(results, r, key_length)
+function _retrieve_value!(results, result_key, prefix_key, key_length)
     rm_key = s -> chop(s, head=key_length, tail=0)
+    if haskey(r, result_key)
+        for p in r[result_key]
+            prefix = _pair_or_dict_get(p, prefix_key)
+            if prefix !== nothing
+                push!(results, rm_key(prefix))
+            end
+        end
+    end
+    return nothing
+end
+
+function _readdir_add_results!(results, r, key_length)
     sizehint!(results, length(results) + parse(Int, r["KeyCount"]))
-    if haskey(r, "CommonPrefixes")
-        for p in r["CommonPrefixes"]
-            prefix = _pair_or_dict_get(p, "Prefix")
-            if prefix !== nothing
-                push!(results, rm_key(prefix))
-            end
-        end
-    end
-    if haskey(r, "Contents")
-        for o in r["Contents"]
-            prefix = _pair_or_dict_get(o, "Key")
-            if prefix !== nothing
-                push!(results, rm_key(prefix))
-            end
-        end
-    end
+    _retrieve_value!(results, "CommonPrefixes", "Prefix", key_length)
+    _retrieve_value!(results, "Contents", "Key", key_length)
     return get(r, "NextContinuationToken", nothing)
 end
 

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -359,7 +359,7 @@ function _retrieve_prefixes!(results, objects, prefix_key, chop_head)
 end
 
 function _readdir_add_results!(results, response, key_length)
-    sizehint!(results, length(results) + parse(Int, r["KeyCount"]))
+    sizehint!(results, length(results) + parse(Int, response["KeyCount"]))
 
     _retrieve_prefixes!(results, get(response, "CommonPrefixes", nothing), "Prefix", key_length)
     _retrieve_prefixes!(results, get(response, "Contents", nothing), "Key", key_length)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -344,14 +344,17 @@ _pair_or_dict_get(d::AbstractDict, k) = get(d, k, nothing)
 
 function _retrieve_value!(results, result_key, prefix_key, key_length)
     rm_key = s -> chop(s, head=key_length, tail=0)
+    
     if haskey(r, result_key)
         for p in r[result_key]
             prefix = _pair_or_dict_get(p, prefix_key)
+            
             if prefix !== nothing
                 push!(results, rm_key(prefix))
             end
         end
     end
+    
     return nothing
 end
 
@@ -359,6 +362,7 @@ function _readdir_add_results!(results, r, key_length)
     sizehint!(results, length(results) + parse(Int, r["KeyCount"]))
     _retrieve_value!(results, "CommonPrefixes", "Prefix", key_length)
     _retrieve_value!(results, "Contents", "Key", key_length)
+
     return get(r, "NextContinuationToken", nothing)
 end
 
@@ -366,13 +370,12 @@ function Base.readdir(fp::S3Path; join=false, sort=true)
     if isdir(fp)
         k = fp.key
         key_length = length(k)
-
         results = String[]
- 
         token = ""
         while token !== nothing
             r = @repeat 4 try
                 params = Dict("delimiter" => "/", "prefix" => k)
+
                 if !isempty(token)
                     params["continuation-token"] = token
                 end

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -364,7 +364,7 @@ function _readdir_add_results!(results, response, key_length)
     _retrieve_prefixes!(results, get(response, "CommonPrefixes", nothing), "Prefix", key_length)
     _retrieve_prefixes!(results, get(response, "Contents", nothing), "Key", key_length)
 
-    return get(r, "NextContinuationToken", nothing)
+    return get(response, "NextContinuationToken", nothing)
 end
 
 function Base.readdir(fp::S3Path; join=false, sort=true)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -376,7 +376,7 @@ function Base.readdir(fp::S3Path; join=false, sort=true)
             @delay_retry if ecode(e) in ["NoSuchBucket"] end
         end
         token = _readdir_add_results!(results, r, key_length)
-        while !isnothing(token)
+        while token !== nothing
             r = @repeat 4 try
                 S3.list_objects_v2(fp.bucket, Dict("delimiter" => "/", "prefix" => k, "continuation-token" => token); aws_config=fp.config)
             catch e

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -332,6 +332,13 @@ end
         # test trailing slash on final piece is included
         @test p"s3://foo/bar" / "baz/" == p"s3://foo/bar/baz/"
     end
+
+    @testset "`readdir`" begin
+        path = S3Path("s3://$(bucket_name)/A/A/B.txt"; config = aws)
+        write(path, "test!")
+        results = readdir(S3Path("s3://$(bucket_name)/A/"; config = aws))
+        @test results == ["A/"]
+    end
 end
 
 AWSS3.s3_nuke_bucket(aws, bucket_name)

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -337,6 +337,7 @@ end
         path = S3Path("s3://$(bucket_name)/A/A/B.txt"; config = aws)
         write(path, "test!")
         results = readdir(S3Path("s3://$(bucket_name)/A/"; config = aws))
+
         @test results == ["A/"]
     end
 end

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -333,7 +333,7 @@ end
         @test p"s3://foo/bar" / "baz/" == p"s3://foo/bar/baz/"
     end
 
-    @testset "`readdir`" begin
+    @testset "readdir" begin
         path = S3Path("s3://$(bucket_name)/A/A/B.txt"; config = aws)
         write(path, "test!")
         results = readdir(S3Path("s3://$(bucket_name)/A/"; config = aws))


### PR DESCRIPTION
fixes https://github.com/JuliaCloud/AWSS3.jl/issues/147

Currently, we iterate over all objects with a given prefix, even deeply nested ones; in other words, we essentially do a full `walkpath`, and then truncate the keys to just one level and `unique` them. This is very slow. This makes the default `walkpath` implementation super duper slow, because it repeats an entire `walkpath` for every level of the directory hierarchy! ref #158. This PR will definitely improve performance there, but probably just adding a direct `walkpath` implementation would be even faster.

However, if you pass a `delimiter`, then AWS will just return prefixes up to that delimiter (see e.g. the example "Sample Request: Using the delimiter and prefix parameters"  from https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html#API_ListObjectVersions_RequestSyntax). This is the quick way to do it. It returns both a "Contents" field if there are any objects at that level, plus a "CommonPrefix" field, with the "directories". Our `s3_list_objects` method ignores the "CommonPrefix", which is probably why the current implementation does not pass a delimeter. `s3_list_objects` is also documented to return various pieces of metadata which we don't have for directories listed in the "CommonPrefix".

Instead, I just directly call the s3 API in the new readdir method. I use the `list_objects_v2` API since the continuation tokens are easier to handle than the `marker` system.

This also fixes a small subtle bug: the `s3_get_name` method used in the previous version calls `replace` to remove the key from the start of the returned prefix. This means if we had an object like `s3://bucket/A/A/B.txt` and call `readdir(S3Path("s3://bucket/A/"))` we would get back `B.txt` instead of `A/`.

I added a test for this, and checked locally that it failed on the old version of `readdir` (using Minio):
```julia
julia> path = S3Path("s3://$(bucket_name)/A/A/B.txt"; config = aws)
p"s3://ocaws.jl.test.20210622t110746z/A/A/B.txt"

julia> write(path, "test!")
UInt8[]

julia> results = readdir(S3Path("s3://$(bucket_name)/A/"; config = aws))
1-element Vector{SubString{String}}:
 "B.txt"

julia> @test results == ["A/"]
Test Failed at REPL[26]:1
  Expression: results == ["A/"]
   Evaluated: SubString{String}["B.txt"] == ["A/"]
ERROR: There was an error during testing
```