### PR TITLE
make it easier to access by byte range

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.8.5"
+version = "0.8.6"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ s3_enable_versioning(aws, "my.bucket")
 
 s3_put(aws, "my.bucket", "key", "Hello!")
 println(s3_get(aws, "my.bucket", "key"))  # prints "Hello!"
-println(s3_get(aws, "my.bucket", "key", byte_range=0:1))  # prints only "He"
+println(s3_get(aws, "my.bucket", "key", byte_range=1:2))  # prints only "He"
 ```
 
 ## `S3Path`
-This package exports the `S3Path` object. 
+This package exports the `S3Path` object.
 This is an `AbstractPath` object as defined by [FilePathsBase.jl](https://github.com/rofinn/FilePathsBase.jl), allowing users to use
 Julia's `Base` [file system interface](https://docs.julialang.org/en/v1/base/file/) to
 obtain information from S3 buckets.
@@ -60,7 +60,7 @@ Status(
 julia> String(read(file))  # fetch the file into memory
 "this is a file for testing S3Path\n"
 
-julia> String(read(file, byte_range=0:3))  # fetch a specific byte range of the file
+julia> String(read(file, byte_range=1:4))  # fetch a specific byte range of the file
 "this"
 
 julia> rm(file)  # delete the file

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ s3_create_bucket(aws, "my.bucket")
 s3_enable_versioning(aws, "my.bucket")
 
 s3_put(aws, "my.bucket", "key", "Hello!")
-println(s3_get(aws, "my.bucket", "key"))
+println(s3_get(aws, "my.bucket", "key"))  # prints "Hello!"
+println(s3_get(aws, "my.bucket", "key", byte_range=0:1))  # prints only "He"
 ```
 
 ## `S3Path`
@@ -58,6 +59,9 @@ Status(
 
 julia> String(read(file))  # fetch the file into memory
 "this is a file for testing S3Path\n"
+
+julia> String(read(file, byte_range=0:3))  # fetch a specific byte range of the file
+"this"
 
 julia> rm(file)  # delete the file
 UInt8[]

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -114,7 +114,7 @@ Like `s3_get` but streams result directly to `filename`.  Keyword arguments acce
 the same as those for `s3_get`.
 """
 function s3_get_file(aws::AbstractAWSConfig, bucket, path, filename; version="", kwargs...)
-    stream = s3_get(aws, bucket, path; kwargs...)
+    stream = s3_get(aws, bucket, path; return_stream=true, kwargs...)
 
     open(filename, "w") do file
         while !eof(stream)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -87,7 +87,7 @@ function s3_get(aws::AbstractAWSConfig, bucket, path; version="", retry=true,
             args["versionId"] = version
         end
 
-        if !isnothing(byte_range)
+        if byte_range ≢ nothing
             headers = copy(headers)  # make sure we don't mutate existing object
             # we make sure we stick to the Julia convention of 1-based indexing
             a, b = (first(byte_range) - 1), (last(byte_range) - 1)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -400,7 +400,9 @@ function Base.readdir(fp::S3Path; join=false, sort=true)
     end
 end
 
-Base.read(fp::S3Path) = Vector{UInt8}(s3_get(fp.config, fp.bucket, fp.key; raw=true))
+function Base.read(fp::S3Path; byte_range=nothing)
+    Vector{UInt8}(s3_get(fp.config, fp.bucket, fp.key; raw=true, byte_range))
+end
 
 Base.write(fp::S3Path, content::String; kwargs...) = Base.write(fp, Vector{UInt8}(content); kwargs...)
 

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -60,7 +60,7 @@ end
     teststr = "123456789"
     s3_put(aws, bucket_name, "byte_range", teststr)
     range = 3:6
-    @test String(s3_get(aws, bucket_name, "byte_range"; headers=Dict{String,String}("Range" => "bytes=$(first(range)-1)-$(last(range)-1)"))) == teststr[range]
+    @test String(s3_get(aws, bucket_name, "byte_range"; byte_range=range)) == teststr[range]
 end
 
 @testset "Object Copy" begin


### PR DESCRIPTION
I somehow did not even know this was a thing even though it's a crucial feature.  Amazingly, there was already a unit test for it.

This PR makes it much nicer for users to specify a byte range and should be non-breaking.