### PR TITLE
use latest config in S3Path's unless passed explicitly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.8.6"
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
@@ -18,6 +19,7 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
 AWS = "1.25"
+Compat = "3.29.0"
 EzXML = "0.9, 1"
 FilePathsBase = "0.9"
 HTTP = "0.8, 0.9"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -32,7 +32,7 @@ using EzXML
 using Dates
 using Base64
 using UUIDs
-using Compat
+using Compat: @something
 
 @service S3
 

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -56,7 +56,7 @@ using Compat: @something
 
 const SSDict = Dict{String,String}
 const AbstractS3Version = Union{AbstractString,Nothing}
-const AbstractS3PathConfig = Union{AbstractAWSConfig, Nothing}
+const AbstractS3PathConfig = Union{AbstractAWSConfig,Nothing}
 
 __init__() = FilePathsBase.register(S3Path)
 

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -56,6 +56,7 @@ using Compat: @something
 
 const SSDict = Dict{String,String}
 const AbstractS3Version = Union{AbstractString,Nothing}
+const AbstractS3PathConfig = Union{AbstractAWSConfig, Nothing}
 
 __init__() = FilePathsBase.register(S3Path)
 

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -32,6 +32,7 @@ using EzXML
 using Dates
 using Base64
 using UUIDs
+using Compat
 
 @service S3
 

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -20,8 +20,8 @@ function S3Path(
     root::AbstractString,
     drive::AbstractString,
     isdirectory::Bool,
-    config::AbstractS3PathConfig,
     version::AbstractS3Version,
+    config::AbstractS3PathConfig,
 )
     return S3Path{typeof(config)}(segments, root, drive, isdirectory, version, config)
 end

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -104,7 +104,7 @@ end
 function S3Path(
     str::AbstractString;
     version::AbstractS3Version=nothing,
-    config::AbstractS3PathConfig=global_aws_config(),
+    config::AbstractS3PathConfig=nothing,
 )
     result = tryparse(S3Path, str; config=config)
     result !== nothing || throw(ArgumentError("Invalid s3 path string: $str"))

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -117,7 +117,9 @@ function S3Path(
     return result
 end
 
-function Base.tryparse(::Type{<:S3Path}, str::AbstractString; config::AbstractS3PathConfig=nothing)
+function Base.tryparse(
+    ::Type{<:S3Path}, str::AbstractString; config::AbstractS3PathConfig=nothing
+)
     uri = URI(str)
     uri.scheme == "s3" || return nothing
 
@@ -204,7 +206,9 @@ end
 # Use `fp.config` unless it is nothing; in that case, get the latest `global_aws_config`
 get_config(fp::S3Path) = @something(fp.config, global_aws_config())
 
-FilePathsBase.exists(fp::S3Path) = s3_exists(get_config(fp), fp.bucket, fp.key; version=fp.version)
+function FilePathsBase.exists(fp::S3Path)
+    return s3_exists(get_config(fp), fp.bucket, fp.key; version=fp.version)
+end
 
 Base.isfile(fp::S3Path) = !fp.isdirectory && exists(fp)
 function Base.isdir(fp::S3Path)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -40,7 +40,7 @@ end
 
 """
     S3Path()
-    S3Path(str; config::$(AbstractS3PathConfig)=nothing, version=nothing)
+    S3Path(str; version::$(AbstractS3Version)=nothing, config::$(AbstractS3PathConfig)=nothing)
 
 Construct a new AWS S3 path type which should be of the form
 "s3://<bucket>/prefix/to/my/object".

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -1,4 +1,6 @@
-struct S3Path{A<:Union{Nothing, AbstractAWSConfig}} <: AbstractPath
+const S3PathConfig = Union{AbstractAWSConfig, Nothing}
+
+struct S3Path{A<:S3PathConfig} <: AbstractPath
     segments::Tuple{Vararg{String}}
     root::String
     drive::String
@@ -8,13 +10,13 @@ end
 
 # constructor that converts but does not require type parameter
 function S3Path(segments, root::AbstractString, drive::AbstractString, isdirectory::Bool,
-                config::Union{Nothing, AbstractAWSConfig})
+                config::S3PathConfig)
     S3Path{typeof(config)}(segments, root, drive, isdirectory, config)
 end
 
 """
     S3Path()
-    S3Path(str; config::Union{Nothing, AbstractAWSConfig}=nothing)
+    S3Path(str; config::$(S3PathConfig)=nothing)
 
 Construct a new AWS S3 path type which should be of the form
 "s3://<bucket>/prefix/to/my/object".
@@ -48,13 +50,13 @@ function S3Path()
     )
 end
 # below definition needed by FilePathsBase
-S3Path{A}() where {A<:Union{Nothing, AbstractAWSConfig}} = S3Path()
+S3Path{A}() where {A<:S3PathConfig} = S3Path()
 
 function S3Path(
     bucket::AbstractString,
     key::AbstractString;
     isdirectory::Bool=false,
-    config::Union{Nothing, AbstractAWSConfig}=nothing,
+    config::S3PathConfig=nothing,
 )
     return S3Path(
         Tuple(filter!(!isempty, split(key, "/"))),
@@ -69,7 +71,7 @@ function S3Path(
     bucket::AbstractString,
     key::AbstractPath;
     isdirectory::Bool=false,
-    config::Union{Nothing, AbstractAWSConfig}=nothing,
+    config::S3PathConfig=nothing,
 )
     return S3Path(
         key.segments,
@@ -81,7 +83,7 @@ function S3Path(
 end
 
 # To avoid a breaking change.
-function S3Path(str::AbstractString; config::Union{Nothing, AbstractAWSConfig}=nothing)
+function S3Path(str::AbstractString; config::S3PathConfig=nothing)
     result = tryparse(S3Path, str; config=config)
     result !== nothing || throw(ArgumentError("Invalid s3 path string: $str"))
     return result

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -1,6 +1,4 @@
-const S3PathConfig = Union{AbstractAWSConfig, Nothing}
-
-struct S3Path{A<:S3PathConfig} <: AbstractPath
+struct S3Path{A<:AbstractS3PathConfig} <: AbstractPath
     segments::Tuple{Vararg{String}}
     root::String
     drive::String
@@ -22,7 +20,7 @@ function S3Path(
     root::AbstractString,
     drive::AbstractString,
     isdirectory::Bool,
-    config::S3PathConfig,
+    config::AbstractS3PathConfig,
     version::AbstractS3Version,
 )
     return S3Path{typeof(config)}(segments, root, drive, isdirectory, version, config)
@@ -42,7 +40,7 @@ end
 
 """
     S3Path()
-    S3Path(str; config::$(S3PathConfig)=nothing, version=nothing)
+    S3Path(str; config::$(AbstractS3PathConfig)=nothing, version=nothing)
 
 Construct a new AWS S3 path type which should be of the form
 "s3://<bucket>/prefix/to/my/object".
@@ -71,14 +69,14 @@ NOTES:
 S3Path() = S3Path((), "/", "", true, nothing, nothing)
 
 # below definition needed by FilePathsBase
-S3Path{A}() where {A<:S3PathConfig} = S3Path()
+S3Path{A}() where {A<:AbstractS3PathConfig} = S3Path()
 
 function S3Path(
     bucket::AbstractString,
     key::AbstractString;
     isdirectory::Bool=false,
     version::AbstractS3Version=nothing,
-    config::S3PathConfig=nothing,
+    config::AbstractS3PathConfig=nothing,
 )
     return S3Path(
         Tuple(filter!(!isempty, split(key, "/"))),
@@ -95,7 +93,7 @@ function S3Path(
     key::AbstractPath;
     isdirectory::Bool=false,
     version::AbstractS3Version=nothing,
-    config::S3PathConfig=nothing,
+    config::AbstractS3PathConfig=nothing,
 )
     return S3Path(
         key.segments, "/", normalize_bucket_name(bucket), isdirectory, version, config
@@ -106,7 +104,7 @@ end
 function S3Path(
     str::AbstractString;
     version::AbstractS3Version=nothing,
-    config::S3PathConfig=global_aws_config(),
+    config::AbstractS3PathConfig=global_aws_config(),
 )
     result = tryparse(S3Path, str; config=config)
     result !== nothing || throw(ArgumentError("Invalid s3 path string: $str"))
@@ -119,7 +117,7 @@ function S3Path(
     return result
 end
 
-function Base.tryparse(::Type{<:S3Path}, str::AbstractString; config::S3PathConfig=nothing)
+function Base.tryparse(::Type{<:S3Path}, str::AbstractString; config::AbstractS3PathConfig=nothing)
     uri = URI(str)
     uri.scheme == "s3" || return nothing
 

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -213,7 +213,7 @@ end
 
 function FilePathsBase.walkpath(fp::S3Path; kwargs...)
     # Select objects with that prefix
-    objects = s3_list_objects(fp.config, fp.bucket, fp.key; delimiter="")
+    objects = s3_list_objects(get_config(fp), fp.bucket, fp.key; delimiter="")
 
     # Construct a new Channel using a recursive internal `_walkpath!` function
     return Channel(ctype=typeof(fp)) do chnl

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -356,14 +356,16 @@ end
 
 # <https://github.com/JuliaCloud/AWSS3.jl/issues/168>
 @testset "Global config is not frozen at construction time" begin
+    prev_config = global_aws_config()
+    
     # Setup: create a file holding a string `abc`
     path = S3Path("s3://$(bucket_name)/test_str.txt")
     write(path, "abc")
+    @test read(path, String) == "abc"  # Have access to read file
 
-    prev_config = global_aws_config()
+    alt_region = prev_config.region == "us-east-2" ? "us-east-1" : "us-east-2"
     try
-        global_aws_config(region="us-east-2") # this is the wrong region!
-        path = S3Path("s3://$(bucket_name)/test_str.txt")
+        global_aws_config(region=alt_region) # this is the wrong region!
         @test_throws AWS.AWSException read(path, String)
 
         # restore the right region

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -548,7 +548,7 @@ function s3path_tests(config)
     end
 
     # <https://github.com/JuliaCloud/AWSS3.jl/issues/168>
-    @testset "Default `S3Path` does not hold config" begin
+    @testset "Default `S3Path` does not freeze config" begin
         path = S3Path("s3://$(bucket_name)/test_str.txt")
         @test path.config === nothing
         @test AWSS3.get_config(path) !== nothing

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -440,8 +440,8 @@ function s3path_tests(config)
     # <https://github.com/JuliaCloud/AWSS3.jl/issues/168>
     @testset "Default `S3Path` does not hold config" begin
         path = S3Path("s3://$(bucket_name)/test_str.txt")
-        @test isnothing(path.config)
-        @test !isnothing(AWSS3.get_config(path))
+        @test path.config === nothing
+        @test AWSS3.get_config(path) !== nothing
     end
 
     # Minio does not care about regions, so this test doesn't work there

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -566,7 +566,7 @@ function s3path_tests(config)
 
             alt_region = prev_config.region == "us-east-2" ? "us-east-1" : "us-east-2"
             try
-                global_aws_config(region=alt_region) # this is the wrong region!
+                global_aws_config(; region=alt_region) # this is the wrong region!
                 @test_throws AWS.AWSException read(path, String)
 
                 # restore the right region

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -356,18 +356,21 @@ end
 
 # <https://github.com/JuliaCloud/AWSS3.jl/issues/168>
 @testset "Global config is not frozen at construction time" begin
+    # Setup: create a file holding a string `abc`
+    path = S3Path("s3://$(bucket_name)/test_str.txt")
+    write(path, "abc")
+
     prev_config = global_aws_config()
     try
         global_aws_config(region="us-east-2") # this is the wrong region!
         path = S3Path("s3://$(bucket_name)/test_str.txt")
-        write(path, "abc")
         @test_throws AWS.AWSException read(path, String)
 
         # restore the right region
         global_aws_config(prev_config)
         # Now it works, without recreating `path`
         @test read(path, String) == "abc"
-
+        rm(path)
     finally
         # In case a test threw, make sure we really do restore the right global config
         global_aws_config(prev_config)


### PR DESCRIPTION
Closes https://github.com/JuliaCloud/AWSS3.jl/issues/168

- [x] needs tests
- [x] decide if its breaking (edit: likely should be breaking to ensure there aren't subtle errors downstream, even though it's somewhat unlikely this behavior is being relied on)

As an aside, I think this plus https://github.com/JuliaCloud/AWSS3.jl/pull/161 will make S3Paths very ergonomic for reproducible usage, e.g.

```julia
module MyModellingPackage

const MyDataSet = S3Path(bucket, key; version)

...fun modelling work...

end # module
```
Then, since it's hardcoded, bumping the dataset means making a new commit, so the code and data versions are always tied for reproducibility (assuming you commit a manifest of course).