### PR TITLE
Limit `isdir` calls in `walkpath`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -40,7 +40,7 @@ using AWS.AWSServices: s3
 using FilePathsBase
 using FilePathsBase: /, join
 using HTTP
-using OrderedCollections: OrderedDict
+using OrderedCollections: OrderedDict, LittleDict
 using SymDict
 using Retry
 using XMLDict
@@ -562,7 +562,7 @@ function s3_list_objects(
     max_items=nothing,
     kwargs...,
 )
-    return Channel() do chnl
+    return Channel(ctype=LittleDict, csize=128) do chnl
         more = true
         num_objects = 0
         token = ""

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -562,7 +562,7 @@ function s3_list_objects(
     max_items=nothing,
     kwargs...,
 )
-    return Channel(ctype=LittleDict, csize=128) do chnl
+    return Channel(; ctype=LittleDict, csize=128) do chnl
         more = true
         num_objects = 0
         token = ""

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -226,16 +226,20 @@ end
 function FilePathsBase.walkpath(fp::S3Path; kwargs...)
     # Select objects with that prefix
     objects = s3_list_objects(get_config(fp), fp.bucket, fp.key; delimiter="")
+    root = joinpath(fp, "/")
 
     # Construct a new Channel using a recursive internal `_walkpath!` function
     return Channel(; ctype=typeof(fp), csize=128) do chnl
-        _walkpath!(fp, fp, Iterators.Stateful(objects), chnl; kwargs...)
+        _walkpath!(root, root, Iterators.Stateful(objects), chnl; kwargs...)
     end
 end
 
 function _walkpath!(
     root::S3Path, prefix::S3Path, objects, chnl; topdown=true, onerror=throw, kwargs...
 )
+    @assert root.isdirectory
+    @assert prefix.isdirectory
+
     while true
         try
             # Start by inspecting the next element
@@ -243,22 +247,37 @@ function _walkpath!(
 
             # Early exit condition if we've exhausted the iterator or just the current prefix.
             next === nothing && return nothing
-            startswith(next["Key"], prefix.key) || return nothing
 
             # Extract the non-root part of the key
             k = chop(next["Key"]; head=length(root.key), tail=0)
 
-            # Determine the next appropriate child path
-            # 1. Next is a direct descendant of the current prefix (ie: we have a prefix object)
-            # 2. Next is a distant descendant of the current prefix (ie: we don't have prefix objects)
             fp = joinpath(root, k)
             _parents = parents(fp)
-            child, recurse = if last(_parents) == prefix || fp.segments == prefix.segments
+
+            # If the filepath matches our prefix then pop it off and continue
+            # Cause we would have already processed it before recursing
+            child = if prefix.segments == fp.segments
                 popfirst!(objects)
-                fp, isdir(fp)
-            else
+                continue
+            # If the filpath is a direct descendant of our prefix then check if it
+            # is a directory too
+            elseif last(_parents) == prefix
+                popfirst!(objects)
+                next_child = Base.peek(objects)
+                if next_child !== nothing && startswith(next_child["Key"], fp.key)
+                    joinpath(fp, "/")
+                else
+                    joinpath(fp, isdir(fp) ? "/" : "")
+                end
+            # If our filepath is a distance descendant of the prefix then start filling in
+            # the intermediate paths
+            elseif prefix in _parents
                 i = findfirst(==(prefix), _parents)
-                _parents[i + 1], true
+                _parents[i + 1]
+            # Otherwise we've established that the current filepath isn't a descendant
+            # of the prefix and we should exit
+            else
+                return nothing
             end
 
             # If we aren't dealing with the root and we're doing topdown iteration then
@@ -266,7 +285,9 @@ function _walkpath!(
             !isempty(k) && topdown && put!(chnl, child)
 
             # Apply our recursive call for the children as necessary
-            if recurse
+            # NOTE: We're relying on the `isdirectory` field rather than calling `isdir`
+            # which will call out to AWS as a fallback.
+            if child.isdirectory
                 _walkpath!(
                     root, child, objects, chnl; topdown=topdown, onerror=onerror, kwargs...
                 )

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -105,22 +105,27 @@ function S3Path(
 )
     result = tryparse(S3Path, str; config=config)
     result !== nothing || throw(ArgumentError("Invalid s3 path string: $str"))
-    if version !== nothing
-        if result.version !== nothing && result.version != version
+    ver = if version !== nothing
+        if  result.version !== nothing && result.version != version
             throw(ArgumentError("Conflicting object versions in `version` and `str`"))
         end
-        result = S3Path(result.bucket, result.key; version=version, config=result.config)
+        version
+    else
+        result.version
     end
 
     # Replace the parsed isdirectory field with an explicit passed in argument.
     is_dir = isdirectory === nothing ? result.isdirectory : isdirectory
 
+    # Warning: We need to use the full constructor because reconstructing with the bucket
+    # and key results in inconsistent `root` fields.
     return S3Path(
-        result.bucket,
-        result.key;
-        isdirectory=is_dir,
-        config=result.config,
-        version=ver,
+        result.segments,
+        result.root,
+        result.drive,
+        is_dir,
+        ver,
+        result.config,
     )
 end
 

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -228,7 +228,7 @@ function FilePathsBase.walkpath(fp::S3Path; kwargs...)
     objects = s3_list_objects(get_config(fp), fp.bucket, fp.key; delimiter="")
 
     # Construct a new Channel using a recursive internal `_walkpath!` function
-    return Channel(; ctype=typeof(fp)) do chnl
+    return Channel(; ctype=typeof(fp), csize=128) do chnl
         _walkpath!(fp, fp, Iterators.Stateful(objects), chnl; kwargs...)
     end
 end

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -8,6 +8,7 @@ function test_s3_constructors(ps::PathSet)
     @test S3Path(bucket_name, "pathset-root/bar/qux/"; isdirectory=true) == ps.qux
     @test S3Path(bucket_name, p"pathset-root/bar/qux"; isdirectory=true) == ps.qux
     @test S3Path(bucket_name, p"/pathset-root/bar/qux"; isdirectory=true) == ps.qux
+    @test S3Path("s3://$bucket_name/pathset-root/bar/qux"; isdirectory=true) == ps.qux
 end
 
 function test_s3_parents(ps::PathSet)

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -451,6 +451,12 @@ function s3path_tests(config)
         @test S3Path("s3://my_bucket/prefix/path/?radtimes=foo&versionId=$ver") ==
               S3Path(("prefix", "path"), "/", "s3://my_bucket", true, ver, cfg)
 
+        # Test to mark inconsistent root string behaviour when reconstructing parsed paths.
+        parsed = tryparse(S3Path, "s3://my_bucket")
+        @test_broken parsed == S3Path(
+            parsed.bucket, parsed.key; version=parsed.version, config=parsed.config
+        )
+
         @test_throws ArgumentError S3Path("s3://my_bucket/?versionId=")
         @test_throws ArgumentError S3Path("s3://my_bucket/?versionId=xyz")
     end


### PR DESCRIPTION
Currently, if `s3_list_objects` return intermediate "directory" objects then we'll need to call `isdir` on the result. Depending on whether these objects include the trailing "/" this `isdir` call may query AWS. These changes attempt to eliminate that requirement by inspect the next element to determine if an object is just a prefix/directory.