### PR TITLE
fix exists functions for directory on AWS S3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -208,7 +208,7 @@ function FilePathsBase.parents(fp::S3Path)
 end
 
 function FilePathsBase.exists(fp::S3Path)
-    return s3_exists(fp.config, fp.bucket, fp.key; version=fp.version)
+    return s3_exists(fp.config, fp.bucket, fp.key; version=fp.version) || isdir(fp)
 end
 Base.isfile(fp::S3Path) = !fp.isdirectory && exists(fp)
 function Base.isdir(fp::S3Path)


### PR DESCRIPTION
This may be a discrepancy between AWS S3 and min.io behavior.  On the S3 bucket I am dealing with, `s3_exists` is returning `false` for a directory that most certainly exists.  My solution is to add an `isdir` check to `exists` (but *NOT* for `s3_exists`).  This shouldn't break anything for anyone.

Btw, tests are failing locally for me (for reasons unrelated to this PR), no clue why.  Will see what the github tests look like before I decide to do anything about it.