### PR TITLE
Refactor some version related code to reduce redundancy

### DIFF
--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -105,9 +105,9 @@ function s3_get(
     kwargs...,
 )
     @repeat 4 try
-        args = Dict{String,Any}("return_raw" => raw, "return_stream" => return_stream)
+        params = Dict{String,Any}("return_raw" => raw, "return_stream" => return_stream)
         if version !== nothing && !isempty(version)
-            args["versionId"] = version
+            params["versionId"] = version
         end
 
         if byte_range ≢ nothing
@@ -118,10 +118,10 @@ function s3_get(
         end
 
         if !isempty(headers)
-            args["headers"] = headers
+            params["headers"] = headers
         end
 
-        return S3.get_object(bucket, path, args; aws_config=aws, kwargs...)
+        return S3.get_object(bucket, path, params; aws_config=aws, kwargs...)
     catch e
         @delay_retry if retry && ecode(e) in ["NoSuchBucket", "NoSuchKey"]
         end

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -184,13 +184,12 @@ Retrieves metadata from an object without returning the object itself.
 function s3_get_meta(
     aws::AbstractAWSConfig, bucket, path; version::AbstractS3Version=nothing, kwargs...
 )
-    if version === nothing || isempty(version)
-        S3.head_object(bucket, path; aws_config=aws, kwargs...)
-    else
-        S3.head_object(
-            bucket, path, Dict("versionId" => version); aws_config=aws, kwargs...
-        )
+    params = Dict{String,Any}()
+    if version !== nothing && !isempty(version)
+        params["versionId"] = version
     end
+
+    return S3.head_object(bucket, path, params; aws_config=aws, kwargs...)
 end
 
 s3_get_meta(a...; b...) = s3_get_meta(global_aws_config(), a...; b...)
@@ -228,13 +227,12 @@ s3_exists(a...; b...) = s3_exists(global_aws_config(), a...; b...)
 function s3_delete(
     aws::AbstractAWSConfig, bucket, path; version::AbstractS3Version=nothing, kwargs...
 )
-    if version === nothing || isempty(version)
-        S3.delete_object(bucket, path; aws_config=aws, kwargs...)
-    else
-        S3.delete_object(
-            bucket, path, Dict("versionId" => version); aws_config=aws, kwargs...
-        )
+    params = Dict{String,Any}()
+    if version !== nothing && !isempty(version)
+        params["versionId"] = version
     end
+
+    return S3.delete_object(bucket, path, params; aws_config=aws, kwargs...)
 end
 
 s3_delete(a...; b...) = s3_delete(global_aws_config(), a...; b...)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -118,10 +118,9 @@ function normalize_bucket_name(bucket)
 end
 
 function Base.print(io::IO, fp::S3Path)
-    if fp.version === nothing || isempty(fp.version)
-        return print(io, fp.anchor, fp.key)
-    end
-    return print(io, fp.anchor, fp.key, "?versionId=", fp.version)
+    print(io, fp.anchor, fp.key)
+    fp.version !== nothing && !isempty(fp.version) && print(io, "?versionId=", fp.version)
+    return nothing
 end
 
 function Base.:(==)(a::S3Path, b::S3Path)


### PR DESCRIPTION
- Avoid separate calls to `S3` functions in favour of building up arguments
- Use `params` instead of `args` as this matches the `AWS.S3` function definitions and `args` should be reserved for use by the function for slurping
- Reduce redundant code in `S3Path` printing. Should reduce the possibility of inconsistencies being introduced

Split out from #199 