### PR TITLE
Deprecate empty version string (0.8 backport)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -195,6 +195,32 @@ function awss3_tests(config)
         @test s3_exists(bucket_name, key_name)
     end
 
+    @testset "Version is empty" begin
+        # Create the file to ensure we're only testing `version`
+        k = "version_empty.txt"
+        s3_put(config, bucket_name, k, "v1")
+        s3_put(config, bucket_name, k, "v2")
+
+        # Using an empty string as the version returns the latest version
+        @test (@test_deprecated s3_get(bucket_name, k; version="")) == "v2"
+        @test (@test_deprecated s3_get_meta(bucket_name, k; version="")) isa AbstractDict
+        @test (@test_deprecated s3_exists(bucket_name, k; version=""))
+        @test (@test_deprecated s3_delete(bucket_name, k; version="")) == UInt8[]
+    end
+
+    @testset "Version is nothing" begin
+        # Create the file to ensure we're only testing `version`
+        k = "version_nothing.txt"
+        s3_put(config, bucket_name, k, "v1")
+        s3_put(config, bucket_name, k, "v2")
+
+        # Using an empty string as the version returns the latest version
+        @test s3_get(bucket_name, k; version=nothing) == "v2"
+        @test s3_get_meta(bucket_name, k; version=nothing) isa AbstractDict
+        @test s3_exists(bucket_name, k; version=nothing)
+        @test s3_delete(bucket_name, k; version=nothing) == UInt8[]
+    end
+
     if is_aws(config)
         @testset "Empty and Delete Bucket" begin
             AWSS3.s3_nuke_bucket(config, bucket_name)

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -456,6 +456,13 @@ function s3path_tests(config)
               S3Path(
             ("prefix", "that", "is", "fun"), "/", "s3://my_bucket", true, "xyz", cfg
         )
+
+        @test_deprecated S3Path("s3://my_bucket/?versionId=")
+    end
+
+    @testset "version is empty" begin
+        @test_deprecated S3Path("my_bucket", "path"; version="")
+        @test_deprecated S3Path("s3://my_bucket/"; version="")
     end
 
     # `s3_list_versions` gives `SignatureDoesNotMatch` exceptions on Minio


### PR DESCRIPTION
Deprecating the functionality which will be added in:
- https://github.com/JuliaCloud/AWSS3.jl/pull/199