### PR TITLE
Add `prefix` to `_s3_exists_dir` to avoid permissions issues

### DIFF
--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -230,8 +230,7 @@ the directory name.
 """
 function _s3_exists_dir(aws::AbstractAWSConfig, bucket, path)
     a = chop(string(path)) * "."
-    # note that you are not allowed to use *both* `prefix` and `start-after`
-    q = Dict("delimiter" => "", "max-keys" => 1, "start-after" => a)
+    q = Dict("delimiter" => "", "max-keys" => 1, "start-after" => a, "prefix" => path)
     l = S3.list_objects_v2(bucket, q; aws_config=aws)
     c = get(l, "Contents", nothing)
     c === nothing && return false


### PR DESCRIPTION
The comment here is wrong; you can use both `start-after` and `prefix` on AWS (see the examples here: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_Examples). And in fact, if you have per-prefix access control setup, you need to restrict your queries to the prefix to not get access denied errors.

I am guessing the comment refers to Minio, where this can be solved by a dispatch in Minio.jl. We can see what the tests say.

cc @christopher-dG @ExpandingMan 