### PR TITLE
add no-op `S3Path(::S3Path)` constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -64,6 +64,8 @@ NOTES:
 """
 S3Path() = S3Path((), "/", "", true, nothing, nothing)
 
+S3Path(path::S3Path) = path
+
 # below definition needed by FilePathsBase
 S3Path{A}() where {A<:AbstractS3PathConfig} = S3Path()
 

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -549,6 +549,12 @@ function s3path_tests(config)
         @test AWSS3.get_config(path) !== nothing
     end
 
+    @testset "No-op constructor" begin
+        path = S3Path("s3://$(bucket_name)/test_str.txt")
+        path2 = S3Path(path)
+        @test path == path2
+    end
+
     # Minio does not care about regions, so this test doesn't work there
     if is_aws(config)
         @testset "Global config is not frozen at construction time" begin


### PR DESCRIPTION
This is handy when you want to make sure you're dealing with an S3Path when you may get a string or an S3Path.