### PR TITLE
readdir must return strings for FilePathsBase compatibility

### DIFF
--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -582,7 +582,7 @@ function Base.readdir(fp::S3Path; join=false, sort=true)
         sort && sort!(results)
 
         # Return results, possibly joined with the root path if join=true
-        return join ? joinpath.(fp, results) : results
+        return join ? string.(joinpath.(fp, results)) : results
     else
         throw(ArgumentError("\"$fp\" is not a directory"))
     end


### PR DESCRIPTION
Currently doing `readdir(p, join=true)` returns an array of paths.  This is a problem because FilePathsBase expects it to be strings in all cases.

This is breaking things pretty badly (e.g. even `rm` on directories is currently broken), so I'm hoping we can get this merged relatively quickly.