### PR TITLE
Work around macOS segfaults/stalls on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,8 +26,10 @@ jobs:
         arch:
           - x64
         exclude:
-          # Skip testing earliest version on macOS to make CI faster
-          - version: "1.3"
+          # Only testing a single version of macOS to make CI faster.
+          # Note: Ideally this would be the latest version of Julia but lately
+          # Julia 1.7.1 is generating segmentation faults only on CI.
+          - version: "1"
             os: macOS-latest
     steps:
       - uses: actions/checkout@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
     "Julia 1.3 - ubuntu-latest - x64",
-    "Julia 1 - macOS-latest - x64",
+    "Julia 1.3 - macOS-latest - x64",
     "Julia 1 - ubuntu-latest - x64",
 ]
 delete-merged-branches = true


### PR DESCRIPTION
Noticed in #233 that macOS on Julia 1.3 passed while Julia 1 (1.7.1) would either stall out or segfault on CI only. It seems like this package hasn't been getting enough maintenance lately and this should help unblock things. 