### PR TITLE
Escape unused DateFormat characters

### DIFF
--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -1,6 +1,7 @@
 function awss3_tests(config)
-    bucket_name =
-        "ocaws.jl.test." * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ"))
+    bucket_name = let df = dateformat"yyyymmdd\THHMMSS\Z"
+        "ocaws.jl.test." * lowercase(Dates.format(now(Dates.UTC), df))
+    end
 
     @testset "Create Bucket" begin
         s3_create_bucket(config, bucket_name)


### PR DESCRIPTION
Required to fix errors when running test suite with #231:

```
  Got exception outside of a @test
  type DateTime has no field zone
  Stacktrace:
    [1] getproperty
      @ ./Base.jl:42 [inlined]
    [2] format(io::IOBuffer, d::Dates.DatePart{'Z'}, zdt::DateTime, locale::Dates.DateLocale)
      @ TimeZones ~/.julia/packages/TimeZones/1ALMR/src/parse.jl:81
    [3] macro expansion
      @ /opt/hostedtoolcache/julia/1.7.1/x64/share/julia/stdlib/v1.7/Dates/src/io.jl:634 [inlined]
    [4] format(io::IOBuffer, dt::DateTime, fmt::DateFormat{:yyyymmddTHHMMSSZ, Tuple{Dates.DatePart{'y'}, Dates.DatePart{'m'}, Dates.DatePart{'d'}, Dates.Delim{Char, 1}, Dates.DatePart{'H'}, Dates.DatePart{'M'}, Dates.DatePart{'S'}, Dates.DatePart{'Z'}}})
      @ Dates /opt/hostedtoolcache/julia/1.7.1/x64/share/julia/stdlib/v1.7/Dates/src/io.jl:629
    [5] format(dt::DateTime, fmt::DateFormat{:yyyymmddTHHMMSSZ, Tuple{Dates.DatePart{'y'}, Dates.DatePart{'m'}, Dates.DatePart{'d'}, Dates.Delim{Char, 1}, Dates.DatePart{'H'}, Dates.DatePart{'M'}, Dates.DatePart{'S'}, Dates.DatePart{'Z'}}}, bufsize::Int64)
      @ Dates /opt/hostedtoolcache/julia/1.7.1/x64/share/julia/stdlib/v1.7/Dates/src/io.jl:641
    [6] format(dt::DateTime, fmt::DateFormat{:yyyymmddTHHMMSSZ, Tuple{Dates.DatePart{'y'}, Dates.DatePart{'m'}, Dates.DatePart{'d'}, Dates.Delim{Char, 1}, Dates.DatePart{'H'}, Dates.DatePart{'M'}, Dates.DatePart{'S'}, Dates.DatePart{'Z'}}})
      @ Dates /opt/hostedtoolcache/julia/1.7.1/x64/share/julia/stdlib/v1.7/Dates/src/io.jl:640
    [7] format(dt::DateTime, f::String; locale::Dates.DateLocale)
      @ Dates /opt/hostedtoolcache/julia/1.7.1/x64/share/julia/stdlib/v1.7/Dates/src/io.jl:680
    [8] format
      @ /opt/hostedtoolcache/julia/1.7.1/x64/share/julia/stdlib/v1.7/Dates/src/io.jl:680 [inlined]
    [9] awss3_tests(config::MinioConfig)
      @ Main ~/work/AWSS3.jl/AWSS3.jl/test/awss3.jl:2
   [10] macro expansion
      @ ~/work/AWSS3.jl/AWSS3.jl/test/runtests.jl:43 [inlined]
   [11] macro expansion
      @ /opt/hostedtoolcache/julia/1.7.1/x64/share/julia/stdlib/v1.7/Test/src/Test.jl:1283 [inlined]
   [12] macro expansion
      @ ~/work/AWSS3.jl/AWSS3.jl/test/runtests.jl:43 [inlined]
   [13] macro expansion
      @ /opt/hostedtoolcache/julia/1.7.1/x64/share/julia/stdlib/v1.7/Test/src/Test.jl:1283 [inlined]
   [14] top-level scope
      @ ~/work/AWSS3.jl/AWSS3.jl/test/runtests.jl:23
   [15] include(fname::String)
      @ Base.MainInclude ./client.jl:451
   [16] top-level scope
      @ none:6
   [17] eval
      @ ./boot.jl:373 [inlined]
   [18] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:268
   [19] _start()
      @ Base ./client.jl:495
```