### PR TITLE
Robustly handle case variation in return value of s3_get_meta

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.9.6"
+version = "0.9.7"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -58,6 +58,12 @@ const SSDict = Dict{String,String}
 const AbstractS3Version = Union{AbstractString,Nothing}
 const AbstractS3PathConfig = Union{AbstractAWSConfig,Nothing}
 
+# Utility function to workaround https://github.com/JuliaCloud/AWS.jl/issues/547
+function get_robust_case(x, key)
+    haskey(x, key) && return x[key]
+    return x[lowercase(key)]
+end
+
 __init__() = FilePathsBase.register(S3Path)
 
 # Declare new `parse` function to avoid type piracy
@@ -837,7 +843,7 @@ function s3_upload_part(
         kwargs...,
     )
 
-    return Dict(response.headers)["ETag"]
+    return get_robust_case(Dict(response.headers), "ETag")
 end
 
 function s3_complete_multipart_upload(

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -60,8 +60,9 @@ const AbstractS3PathConfig = Union{AbstractAWSConfig,Nothing}
 
 # Utility function to workaround https://github.com/JuliaCloud/AWS.jl/issues/547
 function get_robust_case(x, key)
-    haskey(x, key) && return x[key]
-    return x[lowercase(key)]
+    lkey = lowercase(key)
+    haskey(x, lkey) && return x[lkey]
+    return x[key]
 end
 
 __init__() = FilePathsBase.register(S3Path)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -333,10 +333,6 @@ function _walkpath!(
     end
 end
 
-function get_robust_case(x, key)
-    haskey(x, key) && return x[key]
-    return x[lowercase(key)]
-end
 """
     stat(fp::S3Path)
 

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -333,6 +333,10 @@ function _walkpath!(
     end
 end
 
+function get_robust_case(x, key)
+    haskey(x, key) && return x[key]
+    return x[lowercase(key)]
+end
 """
     stat(fp::S3Path)
 
@@ -358,9 +362,9 @@ function Base.stat(fp::S3Path)
 
         # Example: "Thu, 03 Jan 2019 21:09:17 GMT"
         last_modified = DateTime(
-            resp["Last-Modified"][1:(end - 4)], dateformat"e, d u Y H:M:S"
+            get_robust_case(resp, "Last-Modified")[1:(end - 4)], dateformat"e, d u Y H:M:S"
         )
-        s = parse(Int, resp["Content-Length"])
+        s = parse(Int, get_robust_case(resp, "Content-Length"))
         blocks = ceil(Int, s / 4096)
     end
 

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -8,7 +8,6 @@ function awss3_tests(config)
         upper_dict = Dict("Foo-Bar" => 1)
         @test AWSS3.get_robust_case(lower_dict, "Foo-Bar") == 1
         @test AWSS3.get_robust_case(upper_dict, "Foo-Bar") == 1
-        @test AWSS3.get_robust_case(Dict(), "Foo-Bar")
         @test_throws KeyError("Foo-Bar") AWSS3.get_robust_case(Dict(), "Foo-Bar")
     end
 

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -3,6 +3,15 @@ function awss3_tests(config)
         "ocaws.jl.test." * lowercase(Dates.format(now(Dates.UTC), df))
     end
 
+    @testset "Robust key selection" begin
+        lower_dict = Dict("foo-bar" => 1)
+        upper_dict = Dict("Foo-Bar" => 1)
+        @test AWSS3.get_robust_case(lower_dict, "Foo-Bar") == 1
+        @test AWSS3.get_robust_case(upper_dict, "Foo-Bar") == 1
+        @test AWSS3.get_robust_case(Dict(), "Foo-Bar")
+        @test_throws KeyError("Foo-Bar") AWSS3.get_robust_case(Dict(), "Foo-Bar")
+    end
+
     @testset "Create Bucket" begin
         s3_create_bucket(config, bucket_name)
         @test bucket_name in s3_list_buckets(config)


### PR DESCRIPTION
The case of keys in the return value `s3_get_meta` can vary. Sometime, in the same julia session, it will be "Content-Length" and other times it will be "content-length". :rage: I'm assuming this is an issue with S3 itself. 

To handle this situation I've written a small helper: `get_robust_case`. There are probably other places where it is useful, but I'm just fixing it for calls to `stat` here (where I often run into this problem).

closes https://github.com/JuliaCloud/AWSS3.jl/issues/252
closes https://github.com/JuliaCloud/AWSS3.jl/issues/246