### PR TITLE
Restrict `ArrowTypes.JuliaType` to `S3Path{Nothing}` to make type fully concrete

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.9.7"
+version = "0.9.8"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -656,7 +656,7 @@ end
 const S3PATH_ARROW_NAME = Symbol("JuliaLang.AWSS3.S3Path")
 ArrowTypes.arrowname(::Type{<:S3Path}) = S3PATH_ARROW_NAME
 ArrowTypes.ArrowType(::Type{<:S3Path}) = String
-ArrowTypes.JuliaType(::Val{S3PATH_ARROW_NAME}, ::Any) = S3Path
+ArrowTypes.JuliaType(::Val{S3PATH_ARROW_NAME}, ::Any) = S3Path{Nothing}
 ArrowTypes.fromarrow(::Type{<:S3Path}, uri_string) = S3Path(uri_string)
 
 function ArrowTypes.toarrow(path::S3Path)

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -435,7 +435,7 @@ function s3path_tests(config)
 
     @testset "Arrow <-> S3Path (de)serialization" begin
         ver = String('A':'Z') * String('0':'5')
-        paths = [
+        paths = Any[
             missing,
             S3Path("s3://$(bucket_name)/a"),
             S3Path("s3://$(bucket_name)/b?versionId=$ver"),

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -435,13 +435,14 @@ function s3path_tests(config)
 
     @testset "Arrow <-> S3Path (de)serialization" begin
         ver = String('A':'Z') * String('0':'5')
-        paths = S3Path[
+        paths = [
+            missing,
             S3Path("s3://$(bucket_name)/a"),
             S3Path("s3://$(bucket_name)/b?versionId=$ver"),
             # format trick: using this comment to force use of multiple lines
         ]
         tbl = Arrow.Table(Arrow.tobuffer((; paths=paths)))
-        @test all(tbl.paths .== paths)
+        @test all(isequal.(tbl.paths, paths))
         push!(paths, S3Path("s3://$(bucket_name)/c"; config=config))
         @test_throws ArgumentError Arrow.tobuffer((; paths=paths))
     end

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -435,7 +435,7 @@ function s3path_tests(config)
 
     @testset "Arrow <-> S3Path (de)serialization" begin
         ver = String('A':'Z') * String('0':'5')
-        paths = Any[
+        paths = Union{Missing,S3Path}[
             missing,
             S3Path("s3://$(bucket_name)/a"),
             S3Path("s3://$(bucket_name)/b?versionId=$ver"),


### PR DESCRIPTION
This fixes #263 by restricting the type that is returned by `JuliaType` to be fully concrete.