### PR TITLE
Add response headers to presigned URL v4

### DIFF
--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -939,8 +939,13 @@ function _s3_sign_url_v4(
     path,
     seconds=3600;
     verb="GET",
-    content_type="application/octet-stream",
     protocol="http",
+    content_type::Union{AbstractString,Nothing}=nothing,
+    content_language::Union{AbstractString,Nothing}=nothing,
+    expires::Union{AbstractString,Nothing}=nothing,
+    cache_control::Union{AbstractString,Nothing}=nothing,
+    content_disposition::Union{AbstractString,Nothing}=nothing,
+    content_encoding::Union{AbstractString,Nothing}=nothing
 )
     path = URIs.escapepath("/$bucket/$path")
 
@@ -985,6 +990,29 @@ function _s3_sign_url_v4(
             collect(headers),
         ),
     )
+
+    # Response header override parameters. It seems like these have to
+    # be a part of the query parameters, but they are not canonical headers.
+    #
+    # We only add them to the query parameters if the corresponding
+    # keyword argument has been set by the user.
+    override_query = OrderedDict{String,String}()
+    for (parameter, value) in (
+        "response-content-type" => content_type,
+        "response-content-language" => content_language,
+        "response-expires" => expires,
+        "response-cache-control" => cache_control,
+        "response-content-disposition" => content_disposition,
+        "response-content-encoding" => content_encoding
+    )
+        if !isnothing(value)
+            override_query[parameter] = value
+        end
+    end
+    # It also seems like they have to come after standard query parameters,
+    # but will need to be alphabetically sorted amongst themselves.
+    sort!(override_query)
+    merge!(query, override_query)
 
     canonical_request = string(
         "$verb\n",
@@ -1046,9 +1074,14 @@ function s3_sign_url(
     path,
     seconds=3600;
     verb="GET",
-    content_type="application/octet-stream",
     protocol="http",
     signature_version="v4",
+    content_type::Union{AbstractString,Nothing}=nothing,
+    content_language::Union{AbstractString,Nothing}=nothing,
+    expires::Union{AbstractString,Nothing}=nothing,
+    cache_control::Union{AbstractString,Nothing}=nothing,
+    content_disposition::Union{AbstractString,Nothing}=nothing,
+    content_encoding::Union{AbstractString,Nothing}=nothing
 )
     if signature_version == "v2"
         _s3_sign_url_v2(
@@ -1057,8 +1090,12 @@ function s3_sign_url(
             path,
             seconds;
             verb=verb,
-            content_type=content_type,
-            protocol=protocol,
+            # previously, v2 version set Request-Content-Type to 'application/octet-stream'
+            # but in v4 it was unset. Hence, to keep backwards compatibility, we still set
+            # content_type for v2 even if the user is not providing their own value (unlike
+            # in the v4 case).
+            content_type=isnothing(content_type) ? "application/octet-stream" : content_type,
+            protocol=protocol
         )
     elseif signature_version == "v4"
         _s3_sign_url_v4(
@@ -1066,9 +1103,9 @@ function s3_sign_url(
             bucket,
             path,
             seconds;
-            verb=verb,
-            content_type=content_type,
-            protocol=protocol,
+            verb, protocol,
+            content_type, content_language, expires, cache_control, content_disposition,
+            content_encoding
         )
     else
         throw(ArgumentError("Unknown signature version $signature_version"))


### PR DESCRIPTION
This adds support for [`response-*` query parameters for overriding response headers](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestParameters) in v4 presigned URLs.

Right now, you can pass `content_type` to `s3_sign_url`, but it only does something for v2, and in v4 it is ignored. So here I am adding `Content-Type` + all the other supported ones, but only to `v4` (as the `v2` version seems to be deprecated).

It was a bit of a trial and error to figure out how exactly they should be incorporated into the signing process, but it seems to work:

```julia
AWSS3.s3_sign_url(
    aws_config, bucket, key, 60;
    verb="GET",
    signature_version="v4",
    protocol="https",
    content_type = "text/html",
    content_disposition = "attachment",
    content_language = "de-DE, en-CA",
    expires = Dates.format(now() + Dates.Hour(1), Dates.RFC1123Format),
    cache_control = "private, no-cache, no-store",
    content_encoding = "deflate",
)
```

leads to the following response when `GET`ed:

```
HTTP/1.1 200 OK
x-amz-id-2: ...
x-amz-request-id: ...
Date: Fri, 27 Jan 2023 05:07:26 GMT
Last-Modified: Thu, 26 Jan 2023 00:09:10 GMT
ETag: "0797e3fead7383ee6f61c523c4582256"
x-amz-version-id: ...
Cache-Control: private, no-cache, no-store
Content-Disposition: attachment
Content-Encoding: deflate
Expires: Fri, 27 Jan 2023 19:07:24
Content-Language: de-DE, en-CA
Accept-Ranges: bytes
Content-Type: text/html
Server: AmazonS3
Content-Length: 93
```

If this broadly looks reasonable, them I'm happy to add some docs and tests as well.