### PR TITLE
Document used permissions and restrict permissions used in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.10.3"
+version = "0.10.4"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -128,7 +128,7 @@ s3_get(aws, bucket, path; headers=Dict{String,String}("Range" => "bytes=\$(first
 - [`s3:GetObjectVersion`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetObjectVersion):
   (conditional): required when `version !== nothing`.
 - [`s3:ListBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-ListBucket)
-  (Optional): allows requests to non-existent objects to throw a exception with HTTP status
+  (optional): allows requests to non-existent objects to throw a exception with HTTP status
   code 404 (Not Found) instead of HTTP status code 403 (Access Denied).
 """
 function s3_get(
@@ -241,7 +241,7 @@ Retrieves metadata from an object without returning the object itself.
 - [`s3:GetObjectVersion`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetObjectVersion):
   (conditional): required when `version !== nothing`.
 - [`s3:ListBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-ListBucket)
-  (Optional): allows requests to non-existent objects to throw a exception with HTTP status
+  (optional): allows requests to non-existent objects to throw a exception with HTTP status
   code 404 (Not Found) instead of HTTP status code 403 (Access Denied).
 """
 function s3_get_meta(
@@ -315,7 +315,7 @@ See [`s3_exists`](@ref) and [`s3_exists_unversioned`](@ref).
 
 - [`s3:GetObjectVersion`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetObjectVersion)
 - [`s3:ListBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-ListBucket)
-  (Optional): allows requests to non-existent objects to throw a exception with HTTP status
+  (optional): allows requests to non-existent objects to throw a exception with HTTP status
   code 404 (Not Found) instead of HTTP status code 403 (Access Denied).
 """
 function s3_exists_versioned(

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -572,10 +572,8 @@ option.
 
 # API Calls
 
-Bucket Tagging:
-- [`PutBucketTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html)
-Object Tagging:
-- [`PutObjectTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html)
+- [`PutBucketTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html)(conditional): used when `path` is not specified (bucket tagging).
+- [`PutObjectTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html) (conditional): used when `path` is specified (object tagging).
 
 # Permissions
 
@@ -619,10 +617,8 @@ See also [`s3_put_tags`](@ref) and [`s3_delete_tags`](@ref).
 
 # API Calls
 
-Bucket Tagging:
-- [`GetBucketTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
-Object Tagging:
-- [`GetObjectTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html)
+- [`GetBucketTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)  (conditional): used when `path` is not specified (bucket tagging).
+- [`GetObjectTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html) (conditional): used when `path` is specified (object tagging).
 
 # Permissions
 
@@ -669,10 +665,8 @@ See also [`s3_put_tags`](@ref) and [`s3_get_tags`](@ref).
 
 # API Calls
 
-Bucket Tagging:
-- [`DeleteBucketTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html)
-Object Tagging:
-- [`DeleteObjectTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html)
+- [`DeleteBucketTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html) (conditional): used when `path` is not specified (bucket tagging).
+- [`DeleteObjectTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html) (conditional): used when `path` is specified (object tagging).
 
 # Permissions
 

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -470,7 +470,7 @@ AWS region associated with the `AbstractAWSConfig` (defaults to "us-east-1").
 
 # Permissions
 
-- [`s3:DeleteBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-CreateBucket)
+- [`s3:CreateBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-CreateBucket)
 """
 function s3_create_bucket(aws::AbstractAWSConfig, bucket; kwargs...)
     r = @protected try

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -897,7 +897,9 @@ specified then all objects in the bucket will be purged.
 - [`s3:ListBucketVersions`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-ListBucketVersions)
 - [`s3:DeleteObjectVersion`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-DeleteObjectVersion)
 """
-function s3_purge_versions(aws::AbstractAWSConfig, bucket, path_prefix="", pattern=""; kwargs...)
+function s3_purge_versions(
+    aws::AbstractAWSConfig, bucket, path_prefix="", pattern=""; kwargs...
+)
     for v in s3_list_versions(aws, bucket, path_prefix; kwargs...)
         if pattern == "" || occursin(pattern, v["Key"])
             if v["IsLatest"] != "true"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -830,7 +830,7 @@ s3_list_keys(a...; b...) = s3_list_keys(global_aws_config(), a...; b...)
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
 
-List metadata about all versions of the objects in the `bucket` matching the matching the
+List metadata about all versions of the objects in the `bucket` matching the
 optional `path_prefix`.
 
 # API Calls

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -123,9 +123,10 @@ s3_get(aws, bucket, path; headers=Dict{String,String}("Range" => "bytes=\$(first
 
 # Permissions
 
-- [`s3:GetObject`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetObject)
+- [`s3:GetObject`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetObject):
+  (conditional): required when `version === nothing`.
 - [`s3:GetObjectVersion`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetObjectVersion):
-  when `version` is not set to `nothing`.
+  (conditional): required when `version !== nothing`.
 - [`s3:ListBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-ListBucket)
   (Optional): allows requests to non-existent objects to throw a exception with HTTP status
   code 404 (Not Found) instead of HTTP status code 403 (Access Denied).
@@ -578,10 +579,10 @@ Object Tagging:
 
 # Permissions
 
-Bucket Tagging:
 - [`s3:PutBucketTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-PutBucketTagging)
-Object Tagging:
+  (conditional): required for when `path` is not specified (bucket tagging).
 - [`s3:PutObjectTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-PutObjectTagging)
+  (conditional): required when `path` is specified (object tagging).
 """
 function s3_put_tags(aws::AbstractAWSConfig, bucket, path, tags::SSDict; kwargs...)
     tag_set = Dict("Tag" => [Dict("Key" => k, "Value" => v) for (k, v) in tags])
@@ -625,10 +626,10 @@ Object Tagging:
 
 # Permissions
 
-Bucket Tagging:
 - [`s3:GetBucketTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetBucketTagging)
-Object Tagging:
+  (conditional): required for when `path` is not specified (bucket tagging).
 - [`s3:GetObjectTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetObjectTagging)
+  (conditional): required when `path` is specified (object tagging).
 """
 function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     @protected try
@@ -675,10 +676,10 @@ Object Tagging:
 
 # Permissions
 
-Bucket Tagging:
 - [`s3:PutBucketTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-PutBucketTagging)
-Object Tagging:
+  (conditional): required for when `path` is not specified (bucket tagging).
 - [`s3:DeleteObjectTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-DeleteObjectTagging)
+  (conditional): required when `path` is specified (object tagging).
 """
 function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     r = if isempty(path)
@@ -697,6 +698,8 @@ s3_delete_tags(a...; b...) = s3_delete_tags(global_aws_config(), a...; b...)
 Deletes an empty bucket. All objects in the bucket must be deleted before a bucket can be
 deleted.
 
+See also [`AWSS3.s3_nuke_bucket`](@ref).
+
 # API Calls
 
 - [`DeleteBucket`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html)
@@ -704,8 +707,6 @@ deleted.
 # Permissions
 
 - [`s3:DeleteBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-DeleteBucket)
-
-See also [`AWSS3.s3_nuke_bucket`](@ref).
 """
 function s3_delete_bucket(aws::AbstractAWSConfig, bucket; kwargs...)
     return parse(S3.delete_bucket(bucket; aws_config=aws, kwargs...))

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -1262,7 +1262,8 @@ usage.
 # Permissions
 
 - [`s3:ListBucketVersions`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-ListBucketVersions)
-- [`s3:DeleteObjectVersion`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-DeleteObjectVersion)
+- [`s3:DeleteObjectVersion`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-DeleteObjectVersion):
+  required even on buckets that do not have versioning enabled.
 - [`s3:DeleteBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-DeleteBucket)
 """
 function s3_nuke_bucket(aws::AbstractAWSConfig, bucket_name)

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -47,6 +47,16 @@ function awss3_tests(config)
         @test s3_get(config, bucket_name, "key2") == b"data2.v1"
         @test s3_get(bucket_name, "key3") == b"data3.v3"
         @test s3_get(bucket_name, "key4") == b"data3.v4"
+
+        try
+            s3_get(bucket_name, "key5")
+        catch e
+            e isa AWSException || rethrow()
+
+            # Will see a 403 status if we lack the `s3:ListBucket` permission.
+            @test e.cause.status == 404
+        end
+
         @test s3_get_meta(bucket_name, "key3")["x-amz-meta-foo"] == "bar"
     end
 
@@ -272,7 +282,7 @@ function awss3_tests(config)
             @test !in(bucket_name, s3_list_buckets(config))
         end
 
-        @testset "Delete Non-Existant Bucket" begin
+        @testset "Delete Non-Existent Bucket" begin
             @test_throws AWS.AWSException s3_delete_bucket(config, bucket_name)
         end
     end

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -1,8 +1,5 @@
-function awss3_tests(config)
-    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-    bucket_name = let df = dateformat"yyyymmdd\THHMMSS\Z"
-        lowercase("awss3.jl.test." * Dates.format(now(Dates.UTC), df))
-    end
+function awss3_tests(base_config)
+    bucket_name = gen_bucket_name()
 
     @testset "Robust key selection" begin
         lower_dict = Dict("foo-bar" => 1)
@@ -13,6 +10,7 @@ function awss3_tests(config)
     end
 
     @testset "Create Bucket" begin
+        config = assume_testset_role("CreateBucketTestset"; base_config)
         s3_create_bucket(config, bucket_name)
         @test bucket_name in s3_list_buckets(config)
         is_aws(config) && s3_enable_versioning(config, bucket_name)
@@ -20,6 +18,7 @@ function awss3_tests(config)
     end
 
     @testset "Bucket Tagging" begin
+        config = assume_testset_role("BucketTaggingTestset"; base_config)
         @test isempty(s3_get_tags(config, bucket_name))
         tags = Dict("A" => "1", "B" => "2", "C" => "3")
         s3_put_tags(config, bucket_name, tags)
@@ -29,6 +28,9 @@ function awss3_tests(config)
     end
 
     @testset "Create Objects" begin
+        config = assume_testset_role("CreateObjectsTestset"; base_config)
+        global_aws_config(config)
+
         s3_put(config, bucket_name, "key1", "data1.v1")
         s3_put(bucket_name, "key2", "data2.v1"; tags=Dict("Key" => "Value"))
         s3_put(config, bucket_name, "key3", "data3.v1")
@@ -49,7 +51,8 @@ function awss3_tests(config)
         @test s3_get(bucket_name, "key4") == b"data3.v4"
 
         try
-            s3_get(bucket_name, "key5")
+            s3_get(config, bucket_name, "key5")
+            @test false
         catch e
             e isa AWSException || rethrow()
 
@@ -61,6 +64,7 @@ function awss3_tests(config)
     end
 
     @testset "ASync Get" begin
+        config = assume_testset_role("ReadObject"; base_config)
         @sync begin
             for i in 1:2
                 @async begin
@@ -71,6 +75,7 @@ function awss3_tests(config)
     end
 
     @testset "Raw Return - XML" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
         xml = "<?xml version='1.0'?><Doc><Text>Hello</Text></Doc>"
         s3_put(config, bucket_name, "file.xml", xml, "text/xml")
         @test String(s3_get(config, bucket_name, "file.xml"; raw=true)) == xml
@@ -78,6 +83,7 @@ function awss3_tests(config)
     end
 
     @testset "Get byte range" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
         teststr = "123456789"
         s3_put(config, bucket_name, "byte_range", teststr)
         range = 3:6
@@ -86,35 +92,41 @@ function awss3_tests(config)
     end
 
     @testset "Object Copy" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
         s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy")
         @test s3_get(config, bucket_name, "key1.copy") == b"data1.v1"
     end
 
     @testset "Object exists" begin
+        config = assume_testset_role("ReadObject"; base_config)
         for key in ["key1", "key2", "key3", "key1.copy"]
-            @test s3_exists(bucket_name, key)
+            @test s3_exists(config, bucket_name, key)
         end
     end
 
     @testset "List Objects" begin
+        config = assume_testset_role("ReadObject"; base_config)
         for key in ["key1", "key2", "key3", "key1.copy"]
             @test key in [o["Key"] for o in s3_list_objects(config, bucket_name)]
         end
     end
 
     @testset "Object Delete" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
         s3_delete(config, bucket_name, "key1.copy")
         @test !("key1.copy" in [o["Key"] for o in s3_list_objects(config, bucket_name)])
     end
 
     @testset "Check Metadata" begin
+        config = assume_testset_role("ReadObject"; base_config)
         meta = s3_get_meta(config, bucket_name, "key1")
         @test meta["ETag"] == "\"68bc8898af64159b72f349b391a7ae35\""
     end
 
+    # https://github.com/samoconnor/AWSS3.jl/issues/24
     @testset "default Content-Type" begin
-        # https://github.com/samoconnor/AWSS3.jl/issues/24
-        ctype(key) = s3_get_meta(bucket_name, key)["Content-Type"]
+        config = assume_testset_role("ReadWriteObject"; base_config)
+        ctype(key) = s3_get_meta(config, bucket_name, key)["Content-Type"]
 
         for k in ["file.foo", "file", "file_html", "file.d/html", "foobar.html/file.htm"]
             is_aws(config) && k == "file" && continue
@@ -139,6 +151,7 @@ function awss3_tests(config)
     end
 
     @testset "Multi-Part Upload" begin
+        config = assume_testset_role("MultipartUploadTestset"; base_config)
         MIN_S3_CHUNK_SIZE = 5 * 1024 * 1024 # 5 MB
         key_name = "multi-part-key"
         upload = s3_begin_multipart_upload(config, bucket_name, key_name)
@@ -152,71 +165,78 @@ function awss3_tests(config)
         end
 
         s3_complete_multipart_upload(config, upload, tags)
-        @test s3_exists(bucket_name, key_name)
+        @test s3_exists(config, bucket_name, key_name)
     end
 
     # these tests are needed because lack of functionality of the underlying AWS API makes certain
     # seemingly inane tasks incredibly tricky: for example checking if an "object" (file or
     # directory) exists is very subtle
     @testset "path naming edge cases" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
+
         # this seemingly arbitrary operation is needed because of the insanely tricky way we
         # need to check for directories
-        s3_put(bucket_name, "testdir.", "") # create an empty file called `testdir.`
-        s3_put(bucket_name, "testdir/", "") # create an empty file called `testdir/` which AWS will treat as an "empty directory"
-        @test s3_exists(bucket_name, "testdir/")
-        @test isdir(S3Path(bucket_name, "testdir/"))
-        @test !isfile(S3Path(bucket_name, "testdir/"))
-        @test s3_exists(bucket_name, "testdir.")
-        @test isfile(S3Path(bucket_name, "testdir."))
-        @test !isdir(S3Path(bucket_name, "testdir."))
-        @test !s3_exists(bucket_name, "testdir")
+        s3_put(config, bucket_name, "testdir.", "") # create an empty file called `testdir.`
+        s3_put(config, bucket_name, "testdir/", "") # create an empty file called `testdir/` which AWS will treat as an "empty directory"
+        @test s3_exists(config, bucket_name, "testdir/")
+        @test isdir(S3Path(bucket_name, "testdir/"; config))
+        @test !isfile(S3Path(bucket_name, "testdir/"; config))
+        @test s3_exists(config, bucket_name, "testdir.")
+        @test isfile(S3Path(bucket_name, "testdir."; config))
+        @test !isdir(S3Path(bucket_name, "testdir."; config))
+        @test !s3_exists(config, bucket_name, "testdir")
 
-        s3_put(bucket_name, "testdir/testfile.txt", "what up")
-        @test s3_exists(bucket_name, "testdir/testfile.txt")
-        @test isfile(S3Path(bucket_name, "testdir/testfile.txt"))
+        s3_put(config, bucket_name, "testdir/testfile.txt", "what up")
+        @test s3_exists(config, bucket_name, "testdir/testfile.txt")
+        @test isfile(S3Path(bucket_name, "testdir/testfile.txt"; config))
         # make sure the directory still "exists" even though there's a key in there now
-        @test s3_exists(bucket_name, "testdir/")
-        @test isdir(S3Path(bucket_name, "testdir/"))
-        @test !isfile(S3Path(bucket_name, "testdir/"))
+        @test s3_exists(config, bucket_name, "testdir/")
+        @test isdir(S3Path(bucket_name, "testdir/"; config))
+        @test !isfile(S3Path(bucket_name, "testdir/"; config))
 
         # but it is still a directory and not an object
-        @test !s3_exists(bucket_name, "testdir")
+        @test !s3_exists(config, bucket_name, "testdir")
     end
 
     @testset "Version is empty" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
+
         # Create the file to ensure we're only testing `version`
         k = "version_empty.txt"
         s3_put(config, bucket_name, k, "v1")
         s3_put(config, bucket_name, k, "v2")
 
         if is_aws(config)
-            @test_throws AWSException s3_get(bucket_name, k; version="")
-            @test_throws AWSException s3_get_meta(bucket_name, k; version="")
-            @test_throws AWSException s3_exists(bucket_name, k; version="")
-            @test_throws AWSException s3_delete(bucket_name, k; version="")
+            @test_throws AWSException s3_get(config, bucket_name, k; version="")
+            @test_throws AWSException s3_get_meta(config, bucket_name, k; version="")
+            @test_throws AWSException s3_exists(config, bucket_name, k; version="")
+            @test_throws AWSException s3_delete(config, bucket_name, k; version="")
         else
             # Using an empty string as the version returns the latest version
-            @test s3_get(bucket_name, k; version="") == "v2"
-            @test s3_get_meta(bucket_name, k; version="") isa AbstractDict
-            @test s3_exists(bucket_name, k; version="")
-            @test s3_delete(bucket_name, k; version="") == UInt8[]
+            @test s3_get(config, bucket_name, k; version="") == "v2"
+            @test s3_get_meta(config, bucket_name, k; version="") isa AbstractDict
+            @test s3_exists(config, bucket_name, k; version="")
+            @test s3_delete(config, bucket_name, k; version="") == UInt8[]
         end
     end
 
     @testset "Version is nothing" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
+
         # Create the file to ensure we're only testing `version`
         k = "version_nothing.txt"
         s3_put(config, bucket_name, k, "v1")
         s3_put(config, bucket_name, k, "v2")
 
         # Using an empty string as the version returns the latest version
-        @test s3_get(bucket_name, k; version=nothing) == "v2"
-        @test s3_get_meta(bucket_name, k; version=nothing) isa AbstractDict
-        @test s3_exists(bucket_name, k; version=nothing)
-        @test s3_delete(bucket_name, k; version=nothing) == UInt8[]
+        @test s3_get(config, bucket_name, k; version=nothing) == "v2"
+        @test s3_get_meta(config, bucket_name, k; version=nothing) isa AbstractDict
+        @test s3_exists(config, bucket_name, k; version=nothing)
+        @test s3_delete(config, bucket_name, k; version=nothing) == UInt8[]
     end
 
-    is_aws(config) && @testset "Sign URL" begin
+    is_aws(base_config) && @testset "Sign URL" begin
+        config = assume_testset_role("SignUrlTestset"; base_config)
         for v in ["v2", "v4"]
             url = s3_sign_url(config, bucket_name, "key1"; signature_version=v)
             curl_output = ""
@@ -248,7 +268,8 @@ function awss3_tests(config)
         end
     end
 
-    is_aws(config) && @testset "Check Object Versions" begin
+    is_aws(base_config) && @testset "Check Object Versions" begin
+        config = assume_testset_role("ReadObjectVersion"; base_config)
         versions = s3_list_versions(config, bucket_name, "key3")
         @test length(versions) == 3
         @test (
@@ -269,20 +290,23 @@ function awss3_tests(config)
         @test read(tmp_file) == b"data3.v2"
     end
 
-    is_aws(config) && @testset "Purge Versions" begin
+    is_aws(base_config) && @testset "Purge Versions" begin
+        config = assume_testset_role("PurgeVersionsTestset"; base_config)
         s3_purge_versions(config, bucket_name, "key3")
         versions = s3_list_versions(config, bucket_name, "key3")
         @test length(versions) == 1
         @test s3_get(config, bucket_name, "key3") == b"data3.v3"
     end
 
-    if is_aws(config)
+    if is_aws(base_config)
         @testset "Empty and Delete Bucket" begin
+            config = assume_testset_role("EmptyAndDeleteBucketTestset"; base_config)
             AWSS3.s3_nuke_bucket(config, bucket_name)
             @test !in(bucket_name, s3_list_buckets(config))
         end
 
         @testset "Delete Non-Existent Bucket" begin
+            config = assume_testset_role("DeleteNonExistentBucketTestset"; base_config)
             @test_throws AWS.AWSException s3_delete_bucket(config, bucket_name)
         end
     end

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -1,6 +1,7 @@
 function awss3_tests(config)
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
     bucket_name = let df = dateformat"yyyymmdd\THHMMSS\Z"
-        "ocaws.jl.test." * lowercase(Dates.format(now(Dates.UTC), df))
+        lowercase("awss3.jl.test." * Dates.format(now(Dates.UTC), df))
     end
 
     @testset "Robust key selection" begin

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -55,28 +55,28 @@ Resources:
             Resource: "*"
           - Effect: Allow
             Action:
-              - s3:GetBucketPolicyStatus
-              - s3:ListBucketByTags
-              - s3:GetBucketTagging
-              - s3:PutBucketTagging
-              - s3:ListBucketVersions
+              # - s3:GetBucketPolicyStatus
+              # - s3:ListBucketByTags
+              # - s3:GetBucketTagging
+              # - s3:PutBucketTagging
               - s3:CreateBucket
-              - s3:ListBucket
-              - s3:GetBucketVersioning
-              - s3:DeleteBucket
               - s3:PutBucketVersioning
+              - s3:ListBucketVersions
+              # - s3:ListBucket
+              # - s3:GetBucketVersioning
+              - s3:DeleteBucket
             Resource: arn:aws:s3:::ocaws.jl.test.*
           - Effect: Allow
             Action:
-              - s3:DeleteObjectTagging
-              - s3:PutObject
-              - s3:GetObject
-              - s3:DeleteObjectVersion
-              - s3:GetObjectVersionTagging
-              - s3:PutObjectVersionTagging
-              - s3:GetObjectTagging
-              - s3:PutObjectTagging
-              - s3:DeleteObjectVersionTagging
+          #     - s3:DeleteObjectTagging
+          #     - s3:PutObject
+          #     - s3:GetObject
+          #     - s3:DeleteObjectVersion
+          #     - s3:GetObjectVersionTagging
+          #     - s3:PutObjectVersionTagging
+          #     - s3:GetObjectTagging
+          #     - s3:PutObjectTagging
+          #     - s3:DeleteObjectVersionTagging
               - s3:DeleteObject
-              - s3:GetObjectVersion
+          #     - s3:GetObjectVersion
             Resource: arn:aws:s3:::ocaws.jl.test.*/*

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -17,6 +17,11 @@ Parameters:
     AllowedPattern: ^[\w.-]+$
     Default: AWSS3.jl
 
+  BucketPrefix:
+    Type: String
+    AllowedPattern: ^[a-z0-9.-]+$
+    Default: awss3.jl.test.
+
 Resources:
   PublicCIRole:
     Type: AWS::IAM::Role
@@ -40,64 +45,509 @@ Resources:
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/master
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: sts:AssumeRole
 
-  S3TestPolicy:
+  PublicCIAssumePolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub ${GitHubRepo}-S3TestPolicy
+      PolicyName: PublicCIAssumeRoles
       Roles:
         - !Ref PublicCIRole
       PolicyDocument:
         Version: 2012-10-17
-
-        # It isn't necessary to update the names of the tests which requires these permissions.
-        # However, when verifying the minimal set of permissions needed this work was done so it
-        # was also documented.
         Statement:
-          # - Effect: Allow
-          #   Action:
-          #     # For "Create Bucket" tests
-          #     - s3:ListAllMyBuckets
-          #   Resource: "*"
           - Effect: Allow
             Action:
-          #     # For "Create Bucket" tests
-          #     - s3:CreateBucket
-          #     - s3:PutBucketVersioning
-          #     - s3:ListBucketVersions
+              - sts:AssumeRole
+            Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/*
 
-          #     # For "Bucket Tagging" tests
-          #     # - s3:PutBucketTagging
-          #     # - s3:GetBucketTagging
+  # Using separate roles/policies to ensure that each testset only uses the permissions that it
+  # requires. For testset with specific permission requirements we create `*TestsetRole`s where
+  # as testsets with generic permission requirements can reuse roles without the "Testset" suffix.
 
-                # For "Create Objects" tests
-                - s3:ListBucket
-          #     # - s3:GetBucketPolicyStatus
-          #     # - s3:ListBucketByTags
-          #     # - s3:ListBucket
-          #     # - s3:GetBucketVersioning
+  ###
+  ### Testset specific roles/policies
+  ###
 
-          #     # For "Empty and Delete Bucket" and "Delete Non-Existent Bucket" tests
-          #     - s3:DeleteBucket
-              
-            Resource: arn:aws:s3:::awss3.jl.test.*
+  CreateBucketTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-CreateBucketTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  CreateBucketTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-CreateBucketTestset
+      Roles:
+        - !Ref CreateBucketTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
           - Effect: Allow
             Action:
-              # # For "Empty and Delete Bucket"
-              # - s3:DeleteObject
+              - s3:ListAllMyBuckets
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - s3:CreateBucket
+              - s3:PutBucketVersioning
+              - s3:ListBucketVersions
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
 
-              # For "Create Objects" tests
+  BucketTaggingTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-BucketTaggingTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  BucketTaggingTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-BucketTaggingTestset
+      Roles:
+        - !Ref BucketTaggingTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListAllMyBuckets
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - s3:PutBucketTagging
+              - s3:GetBucketTagging
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+
+  CreateObjectsTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-CreateObjectsTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  CreateObjectsTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-CreateObjectsTestset
+      Roles:
+        - !Ref CreateObjectsTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
               - s3:PutObject
               - s3:GetObject
               - s3:PutObjectTagging
               - s3:GetObjectTagging
               - s3:DeleteObjectTagging
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
 
-              # - s3:PutObject
-              # - s3:GetObject
-              # - s3:DeleteObjectVersion
-              # - s3:GetObjectVersionTagging
-              # - s3:PutObjectVersionTagging
-              # - s3:DeleteObjectVersionTagging
-              # - s3:GetObjectVersion
-            Resource: arn:aws:s3:::awss3.jl.test.*/*
+  MultipartUploadTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-MultipartUploadTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  MultipartUploadTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-MultipartUploadTestset
+      Roles:
+        - !Ref MultipartUploadTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          # https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions
+          - Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:ListMultipartUploadParts
+              - s3:AbortMultipartUpload
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  PurgeVersionsTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-PurgeVersionsTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  PurgeVersionsTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-PurgeVersionsTestset
+      Roles:
+        - !Ref PurgeVersionsTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucketVersions
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:DeleteObjectVersion
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  SignUrlTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-SignUrlTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  SignUrlTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-SignUrlTestset
+      Roles:
+        - !Ref SignUrlTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  EmptyAndDeleteBucketTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-EmptyAndDeleteBucketTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  EmptyAndDeleteBucketTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-EmptyAndDeleteBucketTestset
+      Roles:
+        - !Ref EmptyAndDeleteBucketTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListAllMyBuckets
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - s3:ListBucketVersions
+              - s3:DeleteBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:DeleteObjectVersion
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  DeleteNonExistentBucketTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-DeleteNonExistentBucketTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  DeleteNonExistentBucketTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-DeleteNonExistentBucketTestset
+      Roles:
+        - !Ref DeleteNonExistentBucketTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:DeleteBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+
+  S3PathVersioningTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-S3PathVersioningTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  S3PathVersioningTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-S3PathVersioningTestset
+      Roles:
+        - !Ref S3PathVersioningTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:PutBucketVersioning
+              - s3:ListBucket
+              - s3:ListBucketVersions
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:GetObjectVersion
+              - s3:DeleteObjectVersion
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  S3PathNullVersionTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-S3PathNullVersionTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  S3PathNullVersionTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-S3PathNullVersionTestset
+      Roles:
+        - !Ref S3PathNullVersionTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:CreateBucket
+              - s3:PutBucketVersioning
+              - s3:GetBucketVersioning
+              - s3:ListBucketVersions
+              - s3:PutObject
+              - s3:GetObjectVersion
+              - s3:DeleteBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:DeleteObjectVersion
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  ###
+  ### Generic roles/policies
+  ###
+
+  CreateBucketRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-CreateBucket
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  CreateBucketPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-CreateBucket
+      Roles:
+        - !Ref CreateBucketRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:CreateBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+
+  NukeBucketRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-NukeBucket
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  # TODO: May want separate roles/policies for versioned/unversioned buckets
+  NukeBucketPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-NukeBucket
+      Roles:
+        - !Ref NukeBucketRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListAllMyBuckets
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+              - s3:ListBucketVersions
+              - s3:DeleteBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:DeleteObjectVersion
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  ReadObjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-ReadObject
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  # Try to keep separate policies for versioned/unversioned permissions
+  ReadObjectPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-ReadObject
+      Roles:
+        - !Ref ReadObjectRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  ReadObjectVersionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-ReadObjectVersion
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  ReadObjectVersionPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-ReadObjectVersion
+      Roles:
+        - !Ref ReadObjectVersionRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucketVersions
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:GetObjectVersion
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
+  ReadWriteObjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-ReadWriteObject
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  ReadWriteObjectPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-ReadWriteObject
+      Roles:
+        - !Ref ReadWriteObjectRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:DeleteObject
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -65,7 +65,7 @@ Resources:
               # - s3:ListBucket
               # - s3:GetBucketVersioning
               - s3:DeleteBucket
-            Resource: arn:aws:s3:::ocaws.jl.test.*
+            Resource: arn:aws:s3:::awss3.jl.test.*
           - Effect: Allow
             Action:
           #     - s3:DeleteObjectTagging
@@ -79,4 +79,4 @@ Resources:
           #     - s3:DeleteObjectVersionTagging
               - s3:DeleteObject
           #     - s3:GetObjectVersion
-            Resource: arn:aws:s3:::ocaws.jl.test.*/*
+            Resource: arn:aws:s3:::awss3.jl.test.*/*

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -49,34 +49,55 @@ Resources:
         - !Ref PublicCIRole
       PolicyDocument:
         Version: 2012-10-17
+
+        # It isn't necessary to update the names of the tests which requires these permissions.
+        # However, when verifying the minimal set of permissions needed this work was done so it
+        # was also documented.
         Statement:
-          - Effect: Allow
-            Action: s3:ListAllMyBuckets
-            Resource: "*"
+          # - Effect: Allow
+          #   Action:
+          #     # For "Create Bucket" tests
+          #     - s3:ListAllMyBuckets
+          #   Resource: "*"
           - Effect: Allow
             Action:
-              # - s3:GetBucketPolicyStatus
-              # - s3:ListBucketByTags
-              # - s3:GetBucketTagging
-              # - s3:PutBucketTagging
-              - s3:CreateBucket
-              - s3:PutBucketVersioning
-              - s3:ListBucketVersions
-              # - s3:ListBucket
-              # - s3:GetBucketVersioning
-              - s3:DeleteBucket
+          #     # For "Create Bucket" tests
+          #     - s3:CreateBucket
+          #     - s3:PutBucketVersioning
+          #     - s3:ListBucketVersions
+
+          #     # For "Bucket Tagging" tests
+          #     # - s3:PutBucketTagging
+          #     # - s3:GetBucketTagging
+
+                # For "Create Objects" tests
+                - s3:ListBucket
+          #     # - s3:GetBucketPolicyStatus
+          #     # - s3:ListBucketByTags
+          #     # - s3:ListBucket
+          #     # - s3:GetBucketVersioning
+
+          #     # For "Empty and Delete Bucket" and "Delete Non-Existent Bucket" tests
+          #     - s3:DeleteBucket
+              
             Resource: arn:aws:s3:::awss3.jl.test.*
           - Effect: Allow
             Action:
-          #     - s3:DeleteObjectTagging
-          #     - s3:PutObject
-          #     - s3:GetObject
-          #     - s3:DeleteObjectVersion
-          #     - s3:GetObjectVersionTagging
-          #     - s3:PutObjectVersionTagging
-          #     - s3:GetObjectTagging
-          #     - s3:PutObjectTagging
-          #     - s3:DeleteObjectVersionTagging
-              - s3:DeleteObject
-          #     - s3:GetObjectVersion
+              # # For "Empty and Delete Bucket"
+              # - s3:DeleteObject
+
+              # For "Create Objects" tests
+              - s3:PutObject
+              - s3:GetObject
+              - s3:PutObjectTagging
+              - s3:GetObjectTagging
+              - s3:DeleteObjectTagging
+
+              # - s3:PutObject
+              # - s3:GetObject
+              # - s3:DeleteObjectVersion
+              # - s3:GetObjectVersionTagging
+              # - s3:PutObjectVersionTagging
+              # - s3:DeleteObjectVersionTagging
+              # - s3:GetObjectVersion
             Resource: arn:aws:s3:::awss3.jl.test.*/*

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -434,7 +434,6 @@ Resources:
               AWS: !GetAtt PublicCIRole.Arn
             Action: sts:AssumeRole
 
-  # TODO: May want separate roles/policies for versioned/unversioned buckets
   NukeBucketPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -446,11 +445,6 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - s3:ListAllMyBuckets
-            Resource: "*"
-          - Effect: Allow
-            Action:
-              - s3:ListBucket
               - s3:ListBucketVersions
               - s3:DeleteBucket
             Resource: !Sub arn:aws:s3:::${BucketPrefix}*

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -45,10 +45,10 @@ Resources:
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/master
-          - Effect: Allow
-            Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-            Action: sts:AssumeRole
+          # - Effect: Allow
+          #   Principal:
+          #     AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+          #   Action: sts:AssumeRole
 
   PublicCIAssumePolicy:
     Type: AWS::IAM::Policy

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,27 +25,11 @@ include("s3path.jl") # creates `awss3_tests(config)`
 include("awss3.jl") # creates `s3path_tests(config)`
 
 @testset "AWSS3.jl" begin
+    # We can run most tests locally under MinIO without requring AWS credentials
     @testset "Minio" begin
-        # We run most tests under Minio. This can be done locally by those
-        # without access to the s3 bucket under which CI is performed.
-        # We then run all tests with s3 directly.
-
-        port = 9005
-        minio_server = Minio.Server([mktempdir()]; address="localhost:$port")
-
-        try
-            run(minio_server; wait=false)
-            sleep(0.5)  # give the server just a bit of time, though it is amazingly fast to start
-            config = global_aws_config(
-                MinioConfig(
-                    "http://localhost:$port"; username="minioadmin", password="minioadmin"
-                ),
-            )
+        minio_server() do config
             awss3_tests(config)
             s3path_tests(config)
-        finally
-            # Make sure we kill the server even if a test failed.
-            kill(minio_server)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,9 @@ using AWSS3
 using Arrow
 using Dates
 using FilePathsBase
-using FilePathsBase.TestPaths
 using FilePathsBase: /, join
+using FilePathsBase.TestPaths
+using FilePathsBase.TestPaths: test
 using JSON3
 using Minio
 using Mocking
@@ -17,8 +18,7 @@ Mocking.activate()
 
 @service S3 use_response_type = true
 
-is_aws(config) = config isa AWSConfig
-AWS.aws_account_number(::Minio.MinioConfig) = "123"
+include("utils.jl")
 
 # Load the test functions
 include("s3path.jl") # creates `awss3_tests(config)`
@@ -50,9 +50,8 @@ include("awss3.jl") # creates `s3path_tests(config)`
     end
 
     @testset "S3" begin
-        # Set `AWSConfig` as the default for the following tests
-        aws = global_aws_config(AWSConfig())
-        awss3_tests(aws)
-        s3path_tests(aws)
+        config = AWSConfig()
+        awss3_tests(config)
+        s3path_tests(config)
     end
 end

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -161,8 +161,8 @@ function test_s3_properties(base_config::AbstractAWSConfig)
     return ps -> @testset "s3_properties" begin
         config = assume_testset_role("ReadWriteObject"; base_config)
 
-        fp1 = parse(S3Path, "s3://mybucket/path/to/some/object"; config)
-        fp2 = parse(S3Path, "s3://mybucket/path/to/some/prefix/"; config)
+        fp1 = S3Path("s3://mybucket/path/to/some/object"; config)
+        fp2 = S3Path("s3://mybucket/path/to/some/prefix/"; config)
         @test fp1.bucket == "mybucket"
         @test fp1.key == "path/to/some/object"
         @test fp2.bucket == "mybucket"
@@ -304,7 +304,7 @@ function s3path_tests(base_config)
 
     root = let
         config = assume_testset_role("ReadWriteObject"; base_config)
-        parse(S3Path, "s3://$bucket_name/pathset-root/"; config)
+        S3Path("s3://$bucket_name/pathset-root/"; config)
     end
 
     ps = PathSet(

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -147,10 +147,12 @@ function test_s3_sync(ps::PathSet)
     end
 end
 
-function test_s3_properties(ps::PathSet)
-    @testset "s3_properties" begin
-        fp1 = p"s3://mybucket/path/to/some/object"
-        fp2 = p"s3://mybucket/path/to/some/prefix/"
+function test_s3_properties(base_config::AbstractAWSConfig)
+    return ps -> @testset "s3_properties" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
+
+        fp1 = parse(S3Path, "s3://mybucket/path/to/some/object"; config)
+        fp2 = parse(S3Path, "s3://mybucket/path/to/some/prefix/"; config)
         @test fp1.bucket == "mybucket"
         @test fp1.key == "path/to/some/object"
         @test fp2.bucket == "mybucket"
@@ -158,7 +160,7 @@ function test_s3_properties(ps::PathSet)
         @test fp2.version === nothing
 
         try
-            fp3 = S3Path(ps.root.bucket, "/another/testdir/")
+            fp3 = S3Path(ps.root.bucket, "/another/testdir/"; config)
             strs = ["what up", "what else up", "what up again"]
             write(fp3 / "testfile1.txt", strs[1])
             write(fp3 / "testfile2.txt", strs[2])
@@ -169,7 +171,7 @@ function test_s3_properties(ps::PathSet)
             # can be confident timestamps are different
             @test AWSS3.lastmodified(fp3) > AWSS3.lastmodified(ps.foo)
         finally
-            rm(S3Path(ps.root.bucket, "/another/"); recursive=true)  # otherwise subsequent tests may fail
+            rm(S3Path(ps.root.bucket, "/another/"; config); recursive=true)  # otherwise subsequent tests may fail
         end
     end
 end
@@ -218,7 +220,7 @@ function test_large_write(ps::PathSet)
     end
 end
 
-function initialize(bucket_name)
+function initialize(config, bucket_name)
     """
     Hierarchy:
 
@@ -232,14 +234,14 @@ function initialize(bucket_name)
     |       |-- test_04.txt
     |       |-- subdir3/
     """
-    s3_put(bucket_name, "test_01.txt", "test01")
-    s3_put(bucket_name, "emptydir/", "")
-    s3_put(bucket_name, "subdir1/", "")
-    s3_put(bucket_name, "subdir1/test_02.txt", "test02")
-    s3_put(bucket_name, "subdir1/test_03.txt", "test03")
-    s3_put(bucket_name, "subdir1/subdir2/", "")
-    s3_put(bucket_name, "subdir1/subdir2/test_04.txt", "test04")
-    return s3_put(bucket_name, "subdir1/subdir2/subdir3/", "")
+    s3_put(config, bucket_name, "test_01.txt", "test01")
+    s3_put(config, bucket_name, "emptydir/", "")
+    s3_put(config, bucket_name, "subdir1/", "")
+    s3_put(config, bucket_name, "subdir1/test_02.txt", "test02")
+    s3_put(config, bucket_name, "subdir1/test_03.txt", "test03")
+    s3_put(config, bucket_name, "subdir1/subdir2/", "")
+    s3_put(config, bucket_name, "subdir1/subdir2/test_04.txt", "test04")
+    return s3_put(config, bucket_name, "subdir1/subdir2/subdir3/", "")
 end
 
 function verify_files(path::S3Path)
@@ -282,13 +284,18 @@ function verify_files(path::AbstractPath)
 end
 
 # This is the main entrypoint for the S3Path tests
-function s3path_tests(config)
-    bucket_name = let df = dateformat"yyyymmdd\THHMMSS\Z"
-        "ocaws.jl.test." * lowercase(Dates.format(now(Dates.UTC), df))
+function s3path_tests(base_config)
+    bucket_name = gen_bucket_name()
+
+    let
+        config = assume_testset_role("CreateBucket"; base_config)
+        s3_create_bucket(config, bucket_name)
     end
 
-    s3_create_bucket(config, bucket_name)
-    root = Path("s3://$bucket_name/pathset-root/")
+    root = let
+        config = assume_testset_role("ReadWriteObject"; base_config)
+        parse(S3Path, "s3://$bucket_name/pathset-root/"; config)
+    end
 
     ps = PathSet(
         root,
@@ -347,7 +354,7 @@ function s3path_tests(config)
             test_tmpdir,
             test_mktmp,
             test_mktmpdir,
-            test_download,
+            # test_download, # requires `global_aws_config` to work with `download(::S3Path, "s3://...")`
             test_issocket,
             # These will also all work for our custom path type,
             # but many implementations won't support them.
@@ -360,19 +367,27 @@ function s3path_tests(config)
             test_iswritable,
             # test_chown,   # chmod & chown don't make sense for S3Paths
             # test_chmod,
-            test_s3_properties,
+            test_s3_properties(base_config),
             test_s3_folders_and_files,
         ]
 
         # Run all of the automated tests
+        #
+        # Note: `FilePathsBase.TestPaths.test` internally calls an `initialize` function
+        # which requires AWS permissions in order to write some files to S3. Due to this
+        # setup and how `test` passes in `ps` to each test it makes it hard to have each
+        # testset specify their required permissions separately. Currently, we embed the
+        # configuration in the paths themselves but it may make more sense to set the
+        # config globally or create something along the lines of `withenv`.
         test(ps, testsets)
     end
 
     @testset "readdir" begin
-        initialize(bucket_name)
+        config = assume_testset_role("ReadWriteObject"; base_config)
+        initialize(config, bucket_name)
 
         @testset "S3" begin
-            verify_files(S3Path("s3://$bucket_name/"))
+            verify_files(S3Path("s3://$bucket_name/"; config))
             @test_throws ArgumentError("Invalid s3 path string: $bucket_name") S3Path(
                 bucket_name
             )
@@ -382,7 +397,7 @@ function s3path_tests(config)
             temp_path = Path(tempdir() * string(uuid4()))
             mkdir(temp_path)
 
-            sync(S3Path("s3://$bucket_name/"), temp_path)
+            sync(S3Path("s3://$bucket_name/"; config), temp_path)
             verify_files(temp_path)
 
             rm(temp_path; force=true, recursive=true)
@@ -420,6 +435,8 @@ function s3path_tests(config)
     end
 
     @testset "isdir" begin
+        config = assume_testset_role("ReadObject"; base_config)
+
         function _generate_exception(code)
             return AWSException(
                 code, "", nothing, AWS.HTTP.Exceptions.StatusError(404, "", "", ""), nothing
@@ -458,6 +475,8 @@ function s3path_tests(config)
     end
 
     @testset "JSON roundtripping" begin
+        config = assume_testset_role("ReadWriteObject"; base_config)
+
         json_path = S3Path("s3://$(bucket_name)/test_json"; config)
         my_dict = Dict("key" => "value", "key2" => 5.0)
         # here we use the "application/json" MIME type to trigger the heuristic parsing into a `LittleDict`
@@ -479,11 +498,14 @@ function s3path_tests(config)
         ]
         tbl = Arrow.Table(Arrow.tobuffer((; paths=paths)))
         @test all(isequal.(tbl.paths, paths))
-        push!(paths, S3Path("s3://$(bucket_name)/c"; config))
+
+        # Cannot serialize `S3Path`s with embedded `AWSConfig`s.
+        push!(paths, S3Path("s3://$(bucket_name)/c"; config=base_config))
         @test_throws ArgumentError Arrow.tobuffer((; paths))
     end
 
     @testset "tryparse" begin
+        # The global `AWSConfig` is just used for comparison and isn't used for access
         cfg = global_aws_config()
         ver = String('A':'Z') * String('0':'5')
 
@@ -536,8 +558,10 @@ function s3path_tests(config)
     end
 
     # `s3_list_versions` gives `SignatureDoesNotMatch` exceptions on Minio
-    if is_aws(config)
+    if is_aws(base_config)
         @testset "S3Path versioning" begin
+            config = assume_testset_role("S3PathVersioningTestset"; base_config)
+
             s3_enable_versioning(config, bucket_name)
             key = "test_versions"
             s3_put(config, bucket_name, key, "data.v1")
@@ -594,9 +618,9 @@ function s3path_tests(config)
         end
 
         @testset "S3Path null version" begin
-            b = let df = dateformat"yyyymmdd\THHMMSS\Z"
-                "ocaws.jl.test.null." * lowercase(Dates.format(now(Dates.UTC), df))
-            end
+            config = assume_testset_role("S3PathNullVersionTestset"; base_config)
+
+            b = gen_bucket_name("awss3.jl.test.null.")
             k = "object"
 
             function versioning_enabled(config, bucket)
@@ -653,35 +677,34 @@ function s3path_tests(config)
         @test path == path2
     end
 
-    # Minio does not care about regions, so this test doesn't work there
-    if is_aws(config)
+    # MinIO does not care about regions, so this test doesn't work there
+    if is_aws(base_config)
         @testset "Global config is not frozen at construction time" begin
-            prev_config = global_aws_config()
+            config = assume_testset_role("ReadWriteObject"; base_config)
 
-            # Setup: create a file holding a string `abc`
-            path = S3Path("s3://$(bucket_name)/test_str.txt")
-            write(path, "abc")
-            @test read(path, String) == "abc"  # Have access to read file
+            with_aws_config(config) do
+                # Setup: create a file holding a string `abc`
+                path = S3Path("s3://$(bucket_name)/test_str.txt")
+                write(path, "abc")
+                @test read(path, String) == "abc"  # Have access to read file
 
-            alt_region = prev_config.region == "us-east-2" ? "us-east-1" : "us-east-2"
-            try
-                global_aws_config(; region=alt_region) # this is the wrong region!
-                @test_throws AWS.AWSException read(path, String)
+                alt_region = config.region == "us-east-2" ? "us-east-1" : "us-east-2"
+                alt_config = AWSConfig(; region=alt_region) # this is the wrong region!
 
-                # restore the right region
-                global_aws_config(prev_config)
+                with_aws_config(alt_config) do
+                    @test_throws AWS.AWSException read(path, String)
+                end
+
                 # Now it works, without recreating `path`
                 @test read(path, String) == "abc"
                 rm(path)
-            finally
-                # In case a test threw, make sure we really do restore the right global config
-                global_aws_config(prev_config)
             end
         end
     end
 
-    # Broken on minio
-    if is_aws(config)
+    # Broken on MinIO
+    if is_aws(base_config)
+        config = assume_testset_role("NukeBucket"; base_config)
         AWSS3.s3_nuke_bucket(config, bucket_name)
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,79 @@
+const BUCKET_DATE_FORMAT = dateformat"yyyymmdd\THHMMSS\Z"
+
+is_aws(config) = config isa AWSConfig
+AWS.aws_account_number(::Minio.MinioConfig) = "123"
+
+function gen_bucket_name(prefix="awss3.jl.test.")
+    # # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    return lowercase(prefix * Dates.format(now(Dates.UTC), BUCKET_DATE_FORMAT))
+end
+
+function assume_role(
+    role; aws_config::AbstractAWSConfig, duration=nothing, mfa_serial=nothing,
+)
+    if startswith(role, "arn:aws:iam")
+        role_arn = role
+        role_name = basename(role)
+    else
+        response = AWSServices.sts(
+            "GetCallerIdentity";
+            aws_config,
+            feature_set=AWS.FeatureSet(; use_response_type=true),
+        )
+        account_id = parse(response)["GetCallerIdentityResult"]["Account"]
+        role_name = role
+        role_arn = "arn:aws:iam::$account_id:role/$role_name"
+    end
+
+    role_session = AWS._role_session_name(
+        "AWS.jl-role-",
+        role_name,
+        "-" * Dates.format(now(UTC), dateformat"yyyymmdd\THHMMSS\Z"),
+    )
+    params = Dict{String,Any}("RoleArn" => role_arn, "RoleSessionName" => role_session)
+    if duration !== nothing
+        params["DurationSeconds"] = duration
+    end
+    if mfa_serial !== nothing
+        params["SerialNumber"] = mfa_serial
+        token = Base.getpass("Enter MFA code for $mfa_serial")
+        params["TokenCode"] = read(token, String)
+        Base.shred!(token)
+    end
+
+    response = AWSServices.sts(
+        "AssumeRole",
+        params;
+        aws_config,
+        feature_set=AWS.FeatureSet(; use_response_type=true),
+    )
+    dict = parse(response)
+    role_creds = dict["AssumeRoleResult"]["Credentials"]
+    role_user = dict["AssumeRoleResult"]["AssumedRoleUser"]
+    return AWSConfig(;
+        creds=AWSCredentials(
+            role_creds["AccessKeyId"],
+            role_creds["SecretAccessKey"],
+            role_creds["SessionToken"],
+            role_user["Arn"];
+            expiry=DateTime(rstrip(role_creds["Expiration"], 'Z')),
+            renew=() -> assume_role(config, role_arn; duration, mfa_serial).credentials,
+        ),
+    )
+end
+
+function assume_testset_role(role_suffix; base_config)
+    return assume_role("AWSS3.jl-$role_suffix"; aws_config=base_config)
+end
+
+function with_aws_config(f, config::AbstractAWSConfig)
+    local result
+    old_config = global_aws_config()
+    global_aws_config(config)
+    try
+        result = f()
+    finally
+        global_aws_config(old_config)
+    end
+    return result
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -25,9 +25,7 @@ function gen_bucket_name(prefix="awss3.jl.test.")
     return lowercase(prefix * Dates.format(now(Dates.UTC), BUCKET_DATE_FORMAT))
 end
 
-function assume_role(
-    aws_config::AbstractAWSConfig, role; duration=nothing, mfa_serial=nothing
-)
+function assume_role(aws_config::AbstractAWSConfig, role; duration=nothing)
     if startswith(role, "arn:aws:iam")
         role_arn = role
         role_name = basename(role)
@@ -50,12 +48,6 @@ function assume_role(
     params = Dict{String,Any}("RoleArn" => role_arn, "RoleSessionName" => role_session)
     if duration !== nothing
         params["DurationSeconds"] = duration
-    end
-    if mfa_serial !== nothing
-        params["SerialNumber"] = mfa_serial
-        token = Base.getpass("Enter MFA code for $mfa_serial")
-        params["TokenCode"] = read(token, String)
-        Base.shred!(token)
     end
 
     response = AWSServices.sts(

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,9 +11,7 @@ function minio_server(body, dirs=[mktempdir()]; address="localhost:9005")
         sleep(0.5)  # give the server just a bit of time, though it is amazingly fast to start
 
         config = MinioConfig(
-            "http://$address";
-            username="minioadmin",
-            password="minioadmin",
+            "http://$address"; username="minioadmin", password="minioadmin"
         )
         body(config)
     finally
@@ -28,7 +26,7 @@ function gen_bucket_name(prefix="awss3.jl.test.")
 end
 
 function assume_role(
-    aws_config::AbstractAWSConfig, role; duration=nothing, mfa_serial=nothing,
+    aws_config::AbstractAWSConfig, role; duration=nothing, mfa_serial=nothing
 )
     if startswith(role, "arn:aws:iam")
         role_arn = role
@@ -77,7 +75,7 @@ function assume_role(
             role_user["Arn"];
             expiry=DateTime(rstrip(role_creds["Expiration"], 'Z')),
             renew=() -> assume_role(aws_config, role_arn; duration, mfa_serial).credentials,
-        )
+        ),
     )
 end
 


### PR DESCRIPTION
While working on #284 it became evident that we haven't been keeping track of what AWS API calls are used when calling our various exported functions. I started documenting which API calls are used and the required permissions and found myself wanting to update the tests to limit the permissions required for each testset. This PR is the result of those ideas and should allow us to write better test for things like: https://github.com/JuliaCloud/AWSS3.jl/pull/214#issuecomment-924943077.

I'll mention that I didn't document every single function's permissions as part of this PR but I did try to document anything I needed to validate as part of tests. The remaining functions can be done as a follow up.