### PR TITLE
Use `prefix` to support policies restricting access based upon `s3:prefix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Breaking changes
 
-- The `s3_exists`, `isdir(::S3Path)`, and isfile(::S3Path)` calls now specify the `delimiter` to be `"/"` instead of `""` to support IAM policies which allow limited access to specified prefixes (see this [example](https://github.com/JuliaCloud/AWSS3.jl/pull/289#discussion_r1224636214)). Users who previously used the IAM policies conditional `"Condition":{"StringEquals":{"s3:delimiter":[""]}}` in AWSS3.jl v0.10 will need to update their IAM policy to be `"Condition":{"StringEquals":{"s3:delimiter":["","/"]}}` ([#289]).
+- The `s3_exists`, `isdir(::S3Path)`, and `isfile(::S3Path)` calls now specify the `delimiter` to be `"/"` instead of `""` to support IAM policies which allow limited access to specified prefixes (see this [example](https://github.com/JuliaCloud/AWSS3.jl/pull/289#discussion_r1224636214)). Users who previously used the IAM policies conditional `"Condition":{"StringEquals":{"s3:delimiter":[""]}}` in AWSS3.jl v0.10 will need to update their IAM policy to be `"Condition":{"StringEquals":{"s3:delimiter":["","/"]}}` ([#289]).
 
 ## Non-breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# AWSS3.jl v0.11.0 Release Notes
+
+## Breaking changes
+
+- The `s3_exists`, `isdir(::S3Path)`, and isfile(::S3Path)` calls now specify the `delimiter` to be `"/"` instead of `""` to support IAM policies which allow limited access to specified prefixes (see this [example](https://github.com/JuliaCloud/AWSS3.jl/pull/289#discussion_r1224636214)). Users who previously used the IAM policies conditional `"Condition":{"StringEquals":{"s3:delimiter":[""]}}` in AWSS3.jl v0.10 will need to update their IAM policy to be `"Condition":{"StringEquals":{"s3:delimiter":["","/"]}}` ([#289]).
+
+## Non-breaking changes
+
+- The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
+
+[#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Breaking changes
 
-- The `s3_exists`, `isdir(::S3Path)`, and `isfile(::S3Path)` calls now specify the `delimiter` to be `"/"` instead of `""` to support IAM policies which allow limited access to specified prefixes (see this [example](https://github.com/JuliaCloud/AWSS3.jl/pull/289#discussion_r1224636214)). Users who previously used the IAM policies conditional `"Condition":{"StringEquals":{"s3:delimiter":[""]}}` in AWSS3.jl v0.10 will need to update their IAM policy to be `"Condition":{"StringEquals":{"s3:delimiter":["","/"]}}` ([#289]).
+- The `s3_exists`, `isdir(::S3Path)`, and `isfile(::S3Path)` calls now specify the `delimiter` to be `"/"` instead of `""` to support IAM policies which allow limited access to specified prefixes (see this [example](https://github.com/JuliaCloud/AWSS3.jl/pull/289#discussion_r1224636214)). Users who previously used the IAM policies conditional `{"Condition":{"StringEquals":{"s3:delimiter":[""]}}}` with AWSS3.jl v0.10 will need to update their IAM policy to be `{"s3:delimiter":["/"]}` with AWSS3.jl v0.11.0. To maintain compatibility with both versions of AWSS3.jl use the policy `{"s3:delimiter":["","/"]}`. Any policies not using the conditional `s3:delimiter` are unaffected ([#289]).
 
 ## Non-breaking changes
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.10.4"
+version = "0.11.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.11.0"
+version = "0.10.4"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -259,7 +259,7 @@ end
 s3_get_meta(a...; b...) = s3_get_meta(global_aws_config(), a...; b...)
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
-    q = Dict("prefix" => path, "delimiter" => "", "max-keys" => 1)
+    q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
     l = parse(S3.list_objects_v2(bucket, q; aws_config=aws))
     c = get(l, "Contents", nothing)
     c === nothing && return false
@@ -269,29 +269,23 @@ end
 """
     _s3_exists_dir(aws::AbstractAWSConfig, bucket, path)
 
-Internal function used by [`s3_exists`](@ref).
+An internal function used by [`s3_exists`](@ref).
 
-Checks whether the given directory exists.  This is a bit subtle because of how the AWS API
-handles empty directories.  Empty directories are [really just 0-byte objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html#create-folder)
-which are named like directories, i.e. their name has a trailing `"/"`.
+Checks if the given directory exists within the `bucket`. Since S3 uses a flat structure, as
+opposed to being hierarchical like a file system, directories are actually just a collection
+of object keys which share a common prefix. S3 implements empty directories as
+[0-byte objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html#create-folder)
+with keys ending with the delimiter.
 
-What this function does, given a directory name `dir/`, is check for all keys which are
-lexographically greater than `dir.`.  The reason for this is that, if `dir/` is a 0-byte
-object, checking for it directly will not reveal its existence due to some rather peculiar
-design choices on the part of the S3 developers.
-
-In all such cases, if the directory exists it will be seen in the *first* item returned from
-`S3.list_objects_v2`: for empty directories this is because using `start-after` explicitly
-excludes `dir.` itself and `dir/` is next; for directories with actual keys, it is
-guaranteed that the first contained key will start with the directory name.
+It is possible to create non 0-byte objects with a key ending in the delimiter
+(e.g. `s3_put(bucket, "abomination/", "If I cannot inspire love, I will cause fear!")`)
+which the AWS console interprets as the directory "abmonination" containing the object "/".
 """
 function _s3_exists_dir(aws::AbstractAWSConfig, bucket, path)
-    a = chop(string(path)) * "."
-    q = Dict("prefix" => path, "delimiter" => "", "max-keys" => 1, "start-after" => a)
-    l = parse(S3.list_objects_v2(bucket, q; aws_config=aws))
-    c = get(l, "Contents", nothing)
-    c === nothing && return false
-    return startswith(get(c, "Key", ""), path)
+    endswith(path, '/') || throw(ArgumentError("S3 directories must end with '/': $path"))
+    q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
+    r = parse(S3.list_objects_v2(bucket, q; aws_config=aws))
+    return get(r, "KeyCount", "0") != "0"
 end
 
 """

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -288,7 +288,7 @@ the directory name.
 """
 function _s3_exists_dir(aws::AbstractAWSConfig, bucket, path)
     a = chop(string(path)) * "."
-    q = Dict("delimiter" => "", "max-keys" => 1, "start-after" => a, "prefix" => path)
+    q = Dict("prefix" => path, "delimiter" => "", "max-keys" => 1, "start-after" => a)
     l = parse(S3.list_objects_v2(bucket, q; aws_config=aws))
     c = get(l, "Contents", nothing)
     c === nothing && return false
@@ -753,15 +753,18 @@ function s3_list_objects(
         token = ""
 
         while more
-            q = Dict{String,String}()
+            q = Dict{String,String}(
+                "prefix" => path_prefix
+            )
+
             for (name, v) in [
-                ("prefix", path_prefix),
                 ("delimiter", delimiter),
                 ("start-after", start_after),
                 ("continuation-token", token),
             ]
                 isempty(v) || (q[name] = v)
             end
+
             if max_items !== nothing
                 # Note: AWS seems to only return up to 1000 items
                 q["max-keys"] = string(max_items - num_objects)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -269,22 +269,21 @@ end
 """
     _s3_exists_dir(aws::AbstractAWSConfig, bucket, path)
 
-Internal, called by [`s3_exists`](@ref).
+Internal function used by [`s3_exists`](@ref).
 
-Checks whether the given directory exists.  This is a bit subtle because of how the
-AWS API handles empty directories.  Empty directories are really just 0-byte nodes
+Checks whether the given directory exists.  This is a bit subtle because of how the AWS API
+handles empty directories.  Empty directories are [really just 0-byte objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html#create-folder)
 which are named like directories, i.e. their name has a trailing `"/"`.
 
-What this function does is, given a directory name `dir/`, check for all keys which
-are lexographically greater than `dir.`.  The reason for this is that, if `dir/`
-is a 0-byte node, checking for it directly will not reveal its existence due to
-some rather peculiar design choices on the part of the S3 developers.
+What this function does, given a directory name `dir/`, is check for all keys which are
+lexographically greater than `dir.`.  The reason for this is that, if `dir/` is a 0-byte
+object, checking for it directly will not reveal its existence due to some rather peculiar
+design choices on the part of the S3 developers.
 
-In all such cases, if the directory exists it will be seen in the *first* item
-returned from `S3.list_objects_v2`: for empty directories this is because using
-`start-after` explicitly excludes `dir.` itself and `dir/` is next; for directories
-with actual keys, it is guaranteed that the first contained key will start with
-the directory name.
+In all such cases, if the directory exists it will be seen in the *first* item returned from
+`S3.list_objects_v2`: for empty directories this is because using `start-after` explicitly
+excludes `dir.` itself and `dir/` is next; for directories with actual keys, it is
+guaranteed that the first contained key will start with the directory name.
 """
 function _s3_exists_dir(aws::AbstractAWSConfig, bucket, path)
     a = chop(string(path)) * "."

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -746,9 +746,7 @@ function s3_list_objects(
         token = ""
 
         while more
-            q = Dict{String,String}(
-                "prefix" => path_prefix
-            )
+            q = Dict{String,String}("prefix" => path_prefix)
 
             for (name, v) in [
                 ("delimiter", delimiter),

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -259,7 +259,7 @@ end
 s3_get_meta(a...; b...) = s3_get_meta(global_aws_config(), a...; b...)
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
-    q = Dict("prefix" => path, "delimiter" => "", "max-keys" => 1)
+    q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
     l = parse(S3.list_objects_v2(bucket, q; aws_config=aws))
     c = get(l, "Contents", nothing)
     c === nothing && return false

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -288,8 +288,7 @@ the directory name.
 """
 function _s3_exists_dir(aws::AbstractAWSConfig, bucket, path)
     a = chop(string(path)) * "."
-    # note that you are not allowed to use *both* `prefix` and `start-after`
-    q = Dict("delimiter" => "", "max-keys" => 1, "start-after" => a)
+    q = Dict("delimiter" => "", "max-keys" => 1, "start-after" => a, "prefix" => path)
     l = parse(S3.list_objects_v2(bucket, q; aws_config=aws))
     c = get(l, "Contents", nothing)
     c === nothing && return false

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -274,7 +274,7 @@ An internal function used by [`s3_exists`](@ref).
 Checks if the given directory exists within the `bucket`. Since S3 uses a flat structure, as
 opposed to being hierarchical like a file system, directories are actually just a collection
 of object keys which share a common prefix. S3 implements empty directories as
-[0-byte objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html#create-folder)
+[0-byte objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html)
 with keys ending with the delimiter.
 
 It is possible to create non 0-byte objects with a key ending in the delimiter

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -259,7 +259,7 @@ end
 s3_get_meta(a...; b...) = s3_get_meta(global_aws_config(), a...; b...)
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
-    q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
+    q = Dict("prefix" => path, "delimiter" => "", "max-keys" => 1)
     l = parse(S3.list_objects_v2(bucket, q; aws_config=aws))
     c = get(l, "Contents", nothing)
     c === nothing && return false

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -418,12 +418,13 @@ Base.ismount(fp::S3Path) = false
 """
     mkdir(fp::S3Path; recursive=false, exist_ok=false)
 
-Create an empty directory at the S3 path `fp`.  If `recursive`, this will create any previously non-existent
-directories which would contain `fp`.  An error will be thrown if an object exists at `fp` unless `exist_ok`.
+Create an empty directory within an existing bucket for the S3 path `fp`. If `recursive`,
+this will create any previously non-existent directories which would contain `fp`. An error
+will be thrown if an object exists at `fp` unless `exist_ok`.
 
-Note that empty directories in S3 are actually 0-byte objects with the naming convention of a directory.
-
-This will *not* create a bucket.
+!!! note
+    Creating a directory in [S3 creates a 0-byte object](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html#create-folder)
+    with a key set to the provided directory name.
 """
 function Base.mkdir(fp::S3Path; recursive=false, exist_ok=false)
     fp.isdirectory || throw(ArgumentError("S3Path folders must end with '/': $fp"))

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -422,7 +422,7 @@ this will create any previously non-existent directories which would contain `fp
 will be thrown if an object exists at `fp` unless `exist_ok`.
 
 !!! note
-    Creating a directory in [S3 creates a 0-byte object](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html#create-folder)
+    Creating a directory in [S3 creates a 0-byte object](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html)
     with a key set to the provided directory name.
 """
 function Base.mkdir(fp::S3Path; recursive=false, exist_ok=false)

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -244,9 +244,8 @@ function Base.isdir(fp::S3Path)
     fp.isdirectory || return false
     if isempty(fp.segments)  # special handling of buckets themselves
         try
-            @mock S3.list_objects_v2(
-                fp.bucket, Dict("max-keys" => "0"); aws_config=get_config(fp)
-            )
+            params = Dict("prefix" => "", "delimiter" => "/", "max-keys" => "0")
+            @mock S3.list_objects_v2(fp.bucket, params; aws_config=get_config(fp))
             return true
         catch e
             if ecode(e) == "NoSuchBucket"

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -204,14 +204,20 @@ function awss3_tests(base_config)
     # fail with "AccessDenied".
     is_aws(base_config) && @testset "Restricted Prefix" begin
         setup_config = assume_testset_role("ReadWriteObject"; base_config)
-        s3_put(setup_config, bucket_name, "prefix/denied/secrets/top-secret", "for british eyes only")
+        s3_put(
+            setup_config,
+            bucket_name,
+            "prefix/denied/secrets/top-secret",
+            "for british eyes only",
+        )
         s3_put(setup_config, bucket_name, "prefix/granted/file", "hello")
-        @test collect(s3_list_objects(setup_config, bucket_name)) isa Vector
 
         config = assume_testset_role("RestrictedPrefixTestset"; base_config)
         @test s3_exists(config, bucket_name, "prefix/granted/file")
         @test !s3_exists(config, bucket_name, "prefix/granted/dne")
-        @test_throws ["AccessDenied", "403"] s3_exists(config, bucket_name, "prefix/denied/top-secret")
+        @test_throws ["AccessDenied", "403"] begin
+            s3_exists(config, bucket_name, "prefix/denied/top-secret")
+        end
         @test s3_exists(config, bucket_name, "prefix/granted/")
         @test s3_exists(config, bucket_name, "prefix/")
 

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -215,7 +215,7 @@ function awss3_tests(base_config)
         config = assume_testset_role("RestrictedPrefixTestset"; base_config)
         @test s3_exists(config, bucket_name, "prefix/granted/file")
         @test !s3_exists(config, bucket_name, "prefix/granted/dne")
-        @test_throws ["AccessDenied", "403"] begin
+        @test_throws_msg ["AccessDenied", "403"] begin
             s3_exists(config, bucket_name, "prefix/denied/top-secret")
         end
         @test s3_exists(config, bucket_name, "prefix/granted/")

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -272,6 +272,7 @@ Resources:
             Condition:
               StringLike:
                 s3:prefix: ["prefix/granted/*"]
+                s3:delimiter: ["/"]
 
   SignUrlTestsetRole:
     Type: AWS::IAM::Role

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -234,6 +234,45 @@ Resources:
               - s3:DeleteObjectVersion
             Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
 
+  RestrictedPrefixTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-RestrictedPrefixTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  RestrictedPrefixTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-RestrictedPrefixTestset
+      Roles:
+        - !Ref RestrictedPrefixTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowListingOfRootAndPrefix
+            Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+            Condition:
+              StringEquals:
+                s3:prefix: ["", "prefix/"]
+                s3:delimiter: ["/"]
+          - Sid: AllowListingOfPrefixGranted
+            Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+            Condition:
+              StringLike:
+                s3:prefix: ["prefix/granted/*"]
+
   SignUrlTestsetRole:
     Type: AWS::IAM::Role
     Properties:

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -503,7 +503,7 @@ function s3path_tests(base_config)
             @test isdir(S3Path("s3://$(bucket_name)/prefix/"; config))
             @test isdir(S3Path("s3://$(bucket_name)"; config))
 
-            @test_throws ["AccessDenied", "403"] begin
+            @test_throws_msg ["AccessDenied", "403"] begin
                 isdir(S3Path("s3://$(bucket_name)/prefix/denied/"; config))
             end
 
@@ -515,11 +515,11 @@ function s3path_tests(base_config)
             prefixes = [x["Prefix"] for x in parse(r)["CommonPrefixes"]]
             @test "prefix/denied/" in prefixes
 
-            @test_throws ["AccessDenied", "403"] begin
+            @test_throws_msg ["AccessDenied", "403"] begin
                 !isdir(S3Path("s3://$(bucket_name)/prefix/dne/"; config))
             end
 
-            @test_throws ["AccessDenied", "403"] begin
+            @test_throws_msg ["AccessDenied", "403"] begin
                 !isdir(S3Path("s3://$(bucket_name)/prefix/denied/secrets/"; config))
             end
         end

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -490,7 +490,12 @@ function s3path_tests(base_config)
         # fail with "AccessDenied".
         is_aws(base_config) && @testset "Restricted Prefix" begin
             setup_config = assume_testset_role("ReadWriteObject"; base_config)
-            s3_put(setup_config, bucket_name, "prefix/denied/secrets/top-secret", "for british eyes only")
+            s3_put(
+                setup_config,
+                bucket_name,
+                "prefix/denied/secrets/top-secret",
+                "for british eyes only",
+            )
             s3_put(setup_config, bucket_name, "prefix/granted/file", "hello")
 
             config = assume_testset_role("RestrictedPrefixTestset"; base_config)


### PR DESCRIPTION
When [S3 policies are configured to restrict access based upon prefix](https://aws.amazon.com/premiumsupport/knowledge-center/iam-s3-user-specific-folder/) some of our existence checks would fail due to not specifying a `prefix`. The PR #214 attempted to correct this but the usage of `start-after` and `prefix` within the the same query isn't supported by MinIO.

After implementing the test cases against `s3_exists` to validate the problematic behaviour it appeared that the best approach may be to dispatch on `MinioConfig`. However, since AWS.jl only depends on Minio.jl for tests and since Minio.jl depends on AWSS3.jl this fix would require PRs in both packages.

Instead, after reviewing the original implementation of `_s3_exists_dir` it occurred to me that there may be a better approach. As we all know S3 object storage is just a flat structure where each object has a key. A directory is simply a prefix of an existing object which ends in a slash. With this in mind we only care that at least one key exists with the directory prefix. See the updated docstring for `_s3_exists_dir` for more details.

I also noticed that our implementation of `mkdir(::S3Path)` will create empty directory objects for each subdirectory instead of just the deepest directory (e.g. `mkdir(p"s3://bucket/a/b/c/")` creates `s3://bucket/a/`, `s3://bucket/a/b/`, and `s3://bucket/a/b/c/` instead of just `s3://bucket/a/b/c/`). The only reason I can think of for doing this is to ensure that the parent directories will still exist once the deepest empty directory has been removed. However, since object creation doesn't work this same way I think this behaviour is just unnecessarily expensive.

<details>
<summary>Example of MinIO failure when `prefix` and `start-after` are both specified</summary>

```
AWSException: NotImplemented -- A header you provided implies functionality that is not implemented

HTTP.Exceptions.StatusError(501, "GET", "/awss3.jl.test.20230608t165213z?list-type=2&max-keys=1&delimiter=&prefix=prefix%2Fgranted%2F&start-after=prefix%2Fgranted.", HTTP.Messages.Response:
"""
HTTP/1.1 501 Not Implemented
Accept-Ranges: bytes
Content-Length: 366
Content-Security-Policy: block-all-mixed-content
Content-Type: application/xml
Server: MinIO
Strict-Transport-Security: max-age=31536000; includeSubDomains
Vary: Origin, Accept-Encoding
X-Amz-Request-Id: 1766BD4150440788
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block
Date: Thu, 08 Jun 2023 16:53:18 GMT

[Message Body was streamed]""")

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NotImplemented</Code><Message>A header you provided implies functionality that is not implemented</Message><BucketName>awss3.jl.test.20230608t165213z</BucketName><Resource>/awss3.jl.test.20230608t165213z</Resource><RequestId>1766BD4150440788</RequestId><HostId>c64d0898-6ee8-4b36-9888-d1d96029b2c0</HostId></Error>
```
</details>

Supersedes: https://github.com/JuliaCloud/AWSS3.jl/pull/214.
