### PR TITLE
Allow tags to assume OIDC role AWSS3.jl

### DIFF
--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -41,10 +41,12 @@ Resources:
             Condition:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
                 token.actions.githubusercontent.com:sub:
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
                     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/master
+                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/tags/*
           # - Effect: Allow
           #   Principal:
           #     AWS: !Sub arn:aws:iam::${AWS::AccountId}:root


### PR DESCRIPTION
Follow up to #284. When the CI is triggered from a tag the job would be unable to assume the AWSS3.jl role due to a missing trust policy. This was noticed on the v0.10.4 tag and originally thought to be from the PR https://github.com/JuliaCloud/AWSS3.jl/pull/287#issuecomment-1587488362