### PR TITLE
Update CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AWS S3 Interface for Julia
 
-![CI](https://github.com/JuliaCloud/AWSS3.jl/workflows/CI/badge.svg)
+[![CI](https://github.com/JuliaCloud/AWSS3.jl/workflows/CI/badge.svg)](https://github.com/JuliaCloud/AWSS3.jl/actions/workflows/CI.yml)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 


### PR DESCRIPTION
...so that link goes to page with failing/succeeding CI rather than to just the badge.

Old: https://github.com/JuliaCloud/AWSS3.jl/workflows/CI/badge.svg
New: https://github.com/JuliaCloud/AWSS3.jl/actions/workflows/CI.yml