### PR TITLE
Update variable arg lists to named arg lists

### DIFF
--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -558,8 +558,8 @@ function s3_enable_versioning(aws::AbstractAWSConfig, bucket, status="Enabled"; 
     return parse(r)
 end
 
-function s3_enable_versioning(bucket; kwargs...)
-    return s3_enable_versioning(global_aws_config(), bucket; kwargs...)
+function s3_enable_versioning(args...; kwargs...)
+    return s3_enable_versioning(global_aws_config(), args...; kwargs...)
 end
 
 """
@@ -793,8 +793,9 @@ function s3_list_objects(
         end
     end
 end
-function s3_list_objects(bucket, path_prefix=""; kwargs...)
-    return s3_list_objects(global_aws_config(), bucket, path_prefix; kwargs...)
+
+function s3_list_objects(args...; kwargs...)
+    return s3_list_objects(global_aws_config(), args...; kwargs...)
 end
 
 """

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -204,7 +204,9 @@ function s3_get_file(
     end
 end
 
-s3_get_file(bucket, path, filename; kwargs...) = s3_get_file(global_aws_config(), bucket, path, filename; kwargs...)
+function s3_get_file(bucket, path, filename; kwargs...)
+    return s3_get_file(global_aws_config(), bucket, path, filename; kwargs...)
+end
 
 function s3_get_file(
     aws::AbstractAWSConfig,
@@ -257,7 +259,9 @@ function s3_get_meta(
     return Dict(r.headers)
 end
 
-s3_get_meta(bucket, path; kwargs...) = s3_get_meta(global_aws_config(), bucket, path; kwargs...)
+function s3_get_meta(bucket, path; kwargs...)
+    return s3_get_meta(global_aws_config(), bucket, path; kwargs...)
+end
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
     q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
@@ -518,7 +522,9 @@ function s3_put_cors(aws::AbstractAWSConfig, bucket, cors_config; kwargs...)
     return parse(S3.put_bucket_cors(bucket, cors_config; aws_config=aws, kwargs...))
 end
 
-s3_put_cors(bucket, cors_config; kwargs...) = s3_put_cors(AWS.global_aws_config(), bucket, cors_config; kwargs...)
+function s3_put_cors(bucket, cors_config; kwargs...)
+    return s3_put_cors(AWS.global_aws_config(), bucket, cors_config; kwargs...)
+end
 
 """
     s3_enable_versioning([::AbstractAWSConfig], bucket, [status]; kwargs...)
@@ -598,8 +604,12 @@ function s3_put_tags(aws::AbstractAWSConfig, bucket, tags::SSDict; kwargs...)
     return s3_put_tags(aws, bucket, "", tags; kwargs...)
 end
 
-s3_put_tags(bucket, path, tags; kwargs...) = s3_put_tags(global_aws_config(), bucket, path, tags; kwargs...)
-s3_put_tags(bucket, tags; kwargs...) = s3_put_tags(global_aws_config(), bucket, tags; kwargs...)
+function s3_put_tags(bucket, path, tags; kwargs...)
+    return s3_put_tags(global_aws_config(), bucket, path, tags; kwargs...)
+end
+function s3_put_tags(bucket, tags; kwargs...)
+    return s3_put_tags(global_aws_config(), bucket, tags; kwargs...)
+end
 
 """
     s3_get_tags([::AbstractAWSConfig], bucket, [path]; kwargs...)
@@ -647,7 +657,9 @@ function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     end
 end
 
-s3_get_tags(bucket, path=""; kwargs...) = s3_get_tags(global_aws_config(), bucket, path; kwargs...)
+function s3_get_tags(bucket, path=""; kwargs...)
+    return s3_get_tags(global_aws_config(), bucket, path; kwargs...)
+end
 
 """
     s3_delete_tags([::AbstractAWSConfig], bucket, [path])
@@ -678,7 +690,9 @@ function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     return parse(r)
 end
 
-s3_delete_tags(bucket, path=""; kwargs...) = s3_delete_tags(global_aws_config(), bucket, path; kwargs...)
+function s3_delete_tags(bucket, path=""; kwargs...)
+    return s3_delete_tags(global_aws_config(), bucket, path; kwargs...)
+end
 
 """
     s3_delete_bucket([::AbstractAWSConfig], "bucket"; kwargs...)
@@ -784,7 +798,9 @@ function s3_list_objects(
         end
     end
 end
-s3_list_objects(bucket, path_prefix=""; kw...) = s3_list_objects(global_aws_config(), bucket, path_prefix; kw...)
+function s3_list_objects(bucket, path_prefix=""; kw...)
+    return s3_list_objects(global_aws_config(), bucket, path_prefix; kw...)
+end
 
 """
     s3_directory_stat([::AbstractAWSConfig], bucket, path)
@@ -820,7 +836,9 @@ function s3_list_keys(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs...)
     return (o["Key"] for o in s3_list_objects(aws, bucket, path_prefix; kwargs...))
 end
 
-s3_list_keys(bucket, path_prefix=""; kwargs...) = s3_list_keys(global_aws_config(), bucket, path_prefix; kwargs...)
+function s3_list_keys(bucket, path_prefix=""; kwargs...)
+    return s3_list_keys(global_aws_config(), bucket, path_prefix; kwargs...)
+end
 
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -866,7 +884,9 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     return versions
 end
 
-s3_list_versions(bucket, path_prefix=""; kwargs...) = s3_list_versions(global_aws_config(), bucket, path_prefix; kwargs...)
+function s3_list_versions(bucket, path_prefix=""; kwargs...)
+    return s3_list_versions(global_aws_config(), bucket, path_prefix; kwargs...)
+end
 
 """
     s3_purge_versions([::AbstractAWSConfig], bucket, [path_prefix [, pattern]]; kwargs...)
@@ -905,7 +925,9 @@ function s3_purge_versions(
     end
 end
 
-s3_purge_versions(bucket, path_prefix="", pattern=""; kwargs...) = s3_purge_versions(global_aws_config(), bucket, path_prefix, pattern; kwargs...)
+function s3_purge_versions(bucket, path_prefix="", pattern=""; kwargs...)
+    return s3_purge_versions(global_aws_config(), bucket, path_prefix, pattern; kwargs...)
+end
 
 """
     s3_put([::AbstractAWSConfig], bucket, path, data, data_type="", encoding="";

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -558,7 +558,7 @@ function s3_enable_versioning(aws::AbstractAWSConfig, bucket, status="Enabled"; 
     return parse(r)
 end
 
-s3_enable_versioning(a; kwargs...) = s3_enable_versioning(global_aws_config(), a; kwargs...)
+s3_enable_versioning(bucket; kwargs...) = s3_enable_versioning(global_aws_config(), bucket; kwargs...)
 
 """
     s3_put_tags([::AbstractAWSConfig], bucket, [path], tags::Dict; kwargs...)
@@ -798,8 +798,8 @@ function s3_list_objects(
         end
     end
 end
-function s3_list_objects(bucket, path_prefix=""; kw...)
-    return s3_list_objects(global_aws_config(), bucket, path_prefix; kw...)
+function s3_list_objects(bucket, path_prefix=""; kwargs...)
+    return s3_list_objects(global_aws_config(), bucket, path_prefix; kwargs...)
 end
 
 """

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -179,7 +179,7 @@ function s3_get(
     end
 end
 
-s3_get(a...; kwargs...) = s3_get(global_aws_config(), a...; kwargs...)
+s3_get(bucket, path; kwargs...) = s3_get(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_get_file([::AbstractAWSConfig], bucket, path, filename; [version=], kwargs...)
@@ -204,7 +204,7 @@ function s3_get_file(
     end
 end
 
-s3_get_file(a...; kwargs...) = s3_get_file(global_aws_config(), a...; kwargs...)
+s3_get_file(bucket, path, filename; kwargs...) = s3_get_file(global_aws_config(), bucket, path, filename; kwargs...)
 
 function s3_get_file(
     aws::AbstractAWSConfig,
@@ -257,7 +257,7 @@ function s3_get_meta(
     return Dict(r.headers)
 end
 
-s3_get_meta(a...; kwargs...) = s3_get_meta(global_aws_config(), a...; kwargs...)
+s3_get_meta(bucket, path; kwargs...) = s3_get_meta(global_aws_config(), bucket, path; kwargs...)
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
     q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
@@ -381,7 +381,7 @@ function s3_exists(aws::AbstractAWSConfig, bucket, path; version::AbstractS3Vers
         s3_exists_unversioned(aws, bucket, path)
     end
 end
-s3_exists(a...; kwargs...) = s3_exists(global_aws_config(), a...; kwargs...)
+s3_exists(bucket, path; kwargs...) = s3_exists(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_delete([::AbstractAWSConfig], bucket, path; [version], kwargs...)
@@ -408,7 +408,7 @@ function s3_delete(
     return parse(S3.delete_object(bucket, path, params; aws_config=aws, kwargs...))
 end
 
-s3_delete(a...; kwargs...) = s3_delete(global_aws_config(), a...; kwargs...)
+s3_delete(bucket, path; kwargs...) = s3_delete(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_copy([::AbstractAWSConfig], bucket, path; to_bucket=bucket, to_path=path, kwargs...)
@@ -449,7 +449,7 @@ function s3_copy(
     )
 end
 
-s3_copy(a...; kwargs...) = s3_copy(global_aws_config(), a...; kwargs...)
+s3_copy(bucket, path; kwargs...) = s3_copy(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_create_bucket([::AbstractAWSConfig], bucket; kwargs...)
@@ -518,7 +518,7 @@ function s3_put_cors(aws::AbstractAWSConfig, bucket, cors_config; kwargs...)
     return parse(S3.put_bucket_cors(bucket, cors_config; aws_config=aws, kwargs...))
 end
 
-s3_put_cors(a...; kwargs...) = s3_put_cors(AWS.global_aws_config(), a...; kwargs...)
+s3_put_cors(bucket, cors_config; kwargs...) = s3_put_cors(AWS.global_aws_config(), bucket, cors_config; kwargs...)
 
 """
     s3_enable_versioning([::AbstractAWSConfig], bucket, [status]; kwargs...)
@@ -598,7 +598,8 @@ function s3_put_tags(aws::AbstractAWSConfig, bucket, tags::SSDict; kwargs...)
     return s3_put_tags(aws, bucket, "", tags; kwargs...)
 end
 
-s3_put_tags(a...) = s3_put_tags(global_aws_config(), a...)
+s3_put_tags(bucket, path, tags; kwargs...) = s3_put_tags(global_aws_config(), bucket, path, tags; kwargs...)
+s3_put_tags(bucket, tags; kwargs...) = s3_put_tags(global_aws_config(), bucket, tags; kwargs...)
 
 """
     s3_get_tags([::AbstractAWSConfig], bucket, [path]; kwargs...)
@@ -646,7 +647,7 @@ function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     end
 end
 
-s3_get_tags(a...; kwargs...) = s3_get_tags(global_aws_config(), a...; kwargs...)
+s3_get_tags(bucket, path=""; kwargs...) = s3_get_tags(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_delete_tags([::AbstractAWSConfig], bucket, [path])
@@ -677,7 +678,7 @@ function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     return parse(r)
 end
 
-s3_delete_tags(a...; kwargs...) = s3_delete_tags(global_aws_config(), a...; kwargs...)
+s3_delete_tags(bucket, path=""; kwargs...) = s3_delete_tags(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_delete_bucket([::AbstractAWSConfig], "bucket"; kwargs...)
@@ -783,7 +784,7 @@ function s3_list_objects(
         end
     end
 end
-s3_list_objects(a...; kw...) = s3_list_objects(global_aws_config(), a...; kw...)
+s3_list_objects(bucket, path_prefix=""; kw...) = s3_list_objects(global_aws_config(), bucket, path_prefix; kw...)
 
 """
     s3_directory_stat([::AbstractAWSConfig], bucket, path)
@@ -808,7 +809,7 @@ function s3_directory_stat(
     end
     return s, tmlast
 end
-s3_directory_stat(a...) = s3_directory_stat(global_aws_config(), a...)
+s3_directory_stat(bucket, path) = s3_directory_stat(global_aws_config(), bucket, path)
 
 """
     s3_list_keys([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -819,7 +820,7 @@ function s3_list_keys(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs...)
     return (o["Key"] for o in s3_list_objects(aws, bucket, path_prefix; kwargs...))
 end
 
-s3_list_keys(a...; kwargs...) = s3_list_keys(global_aws_config(), a...; kwargs...)
+s3_list_keys(bucket, path_prefix=""; kwargs...) = s3_list_keys(global_aws_config(), bucket, path_prefix; kwargs...)
 
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -865,7 +866,7 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     return versions
 end
 
-s3_list_versions(a...; kwargs...) = s3_list_versions(global_aws_config(), a...; kwargs...)
+s3_list_versions(bucket, path_prefix=""; kwargs...) = s3_list_versions(global_aws_config(), bucket, path_prefix; kwargs...)
 
 """
     s3_purge_versions([::AbstractAWSConfig], bucket, [path_prefix [, pattern]]; kwargs...)
@@ -904,7 +905,7 @@ function s3_purge_versions(
     end
 end
 
-s3_purge_versions(a...; kwargs...) = s3_purge_versions(global_aws_config(), a...; kwargs...)
+s3_purge_versions(bucket, path_prefix="", pattern=""; kwargs...) = s3_purge_versions(global_aws_config(), bucket, path_prefix, pattern; kwargs...)
 
 """
     s3_put([::AbstractAWSConfig], bucket, path, data, data_type="", encoding="";
@@ -981,7 +982,7 @@ function s3_put(
     return parse_response ? parse(response) : response
 end
 
-s3_put(a...; kwargs...) = s3_put(global_aws_config(), a...; kwargs...)
+s3_put(args...; kwargs...) = s3_put(global_aws_config(), args...; kwargs...)
 
 function s3_begin_multipart_upload(
     aws::AbstractAWSConfig,
@@ -1259,7 +1260,7 @@ function s3_sign_url(
     end
 end
 
-s3_sign_url(a...; kwargs...) = s3_sign_url(global_aws_config(), a...; kwargs...)
+s3_sign_url(args...; kwargs...) = s3_sign_url(global_aws_config(), args...; kwargs...)
 
 """
     s3_nuke_bucket([::AbstractAWSConfig], bucket_name)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -558,7 +558,9 @@ function s3_enable_versioning(aws::AbstractAWSConfig, bucket, status="Enabled"; 
     return parse(r)
 end
 
-s3_enable_versioning(bucket; kwargs...) = s3_enable_versioning(global_aws_config(), bucket; kwargs...)
+function s3_enable_versioning(bucket; kwargs...)
+    return s3_enable_versioning(global_aws_config(), bucket; kwargs...)
+end
 
 """
     s3_put_tags([::AbstractAWSConfig], bucket, [path], tags::Dict; kwargs...)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -604,12 +604,7 @@ function s3_put_tags(aws::AbstractAWSConfig, bucket, tags::SSDict; kwargs...)
     return s3_put_tags(aws, bucket, "", tags; kwargs...)
 end
 
-function s3_put_tags(bucket, path, tags; kwargs...)
-    return s3_put_tags(global_aws_config(), bucket, path, tags; kwargs...)
-end
-function s3_put_tags(bucket, tags; kwargs...)
-    return s3_put_tags(global_aws_config(), bucket, tags; kwargs...)
-end
+s3_put_tags(args...; kwargs...) = s3_put_tags(global_aws_config(), args...; kwargs...)
 
 """
     s3_get_tags([::AbstractAWSConfig], bucket, [path]; kwargs...)
@@ -657,9 +652,7 @@ function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     end
 end
 
-function s3_get_tags(bucket, path=""; kwargs...)
-    return s3_get_tags(global_aws_config(), bucket, path; kwargs...)
-end
+s3_get_tags(args...; kwargs...) = s3_get_tags(global_aws_config(), args...; kwargs...)
 
 """
     s3_delete_tags([::AbstractAWSConfig], bucket, [path])
@@ -690,9 +683,7 @@ function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     return parse(r)
 end
 
-function s3_delete_tags(bucket, path=""; kwargs...)
-    return s3_delete_tags(global_aws_config(), bucket, path; kwargs...)
-end
+s3_delete_tags(args...; kwargs...) = s3_delete_tags(global_aws_config(), args...; kwargs...)
 
 """
     s3_delete_bucket([::AbstractAWSConfig], "bucket"; kwargs...)
@@ -713,7 +704,9 @@ See also [`AWSS3.s3_nuke_bucket`](@ref).
 function s3_delete_bucket(aws::AbstractAWSConfig, bucket; kwargs...)
     return parse(S3.delete_bucket(bucket; aws_config=aws, kwargs...))
 end
-s3_delete_bucket(a; kwargs...) = s3_delete_bucket(global_aws_config(), a; kwargs...)
+function s3_delete_bucket(bucket; kwargs...)
+    return s3_delete_bucket(global_aws_config(), bucket; kwargs...)
+end
 
 """
     s3_list_buckets([::AbstractAWSConfig]; kwargs...)
@@ -836,9 +829,7 @@ function s3_list_keys(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs...)
     return (o["Key"] for o in s3_list_objects(aws, bucket, path_prefix; kwargs...))
 end
 
-function s3_list_keys(bucket, path_prefix=""; kwargs...)
-    return s3_list_keys(global_aws_config(), bucket, path_prefix; kwargs...)
-end
+s3_list_keys(args...; kwargs...) = s3_list_keys(global_aws_config(), args...; kwargs...)
 
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -884,8 +875,8 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     return versions
 end
 
-function s3_list_versions(bucket, path_prefix=""; kwargs...)
-    return s3_list_versions(global_aws_config(), bucket, path_prefix; kwargs...)
+function s3_list_versions(args...; kwargs...)
+    return s3_list_versions(global_aws_config(), args...; kwargs...)
 end
 
 """
@@ -925,8 +916,8 @@ function s3_purge_versions(
     end
 end
 
-function s3_purge_versions(bucket, path_prefix="", pattern=""; kwargs...)
-    return s3_purge_versions(global_aws_config(), bucket, path_prefix, pattern; kwargs...)
+function s3_purge_versions(args...; kwargs...)
+    return s3_purge_versions(global_aws_config(), args...; kwargs...)
 end
 
 """

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -179,7 +179,7 @@ function s3_get(
     end
 end
 
-s3_get(a...; b...) = s3_get(global_aws_config(), a...; b...)
+s3_get(a...; kwargs...) = s3_get(global_aws_config(), a...; kwargs...)
 
 """
     s3_get_file([::AbstractAWSConfig], bucket, path, filename; [version=], kwargs...)
@@ -204,7 +204,7 @@ function s3_get_file(
     end
 end
 
-s3_get_file(a...; b...) = s3_get_file(global_aws_config(), a...; b...)
+s3_get_file(a...; kwargs...) = s3_get_file(global_aws_config(), a...; kwargs...)
 
 function s3_get_file(
     aws::AbstractAWSConfig,
@@ -257,7 +257,7 @@ function s3_get_meta(
     return Dict(r.headers)
 end
 
-s3_get_meta(a...; b...) = s3_get_meta(global_aws_config(), a...; b...)
+s3_get_meta(a...; kwargs...) = s3_get_meta(global_aws_config(), a...; kwargs...)
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
     q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
@@ -381,7 +381,7 @@ function s3_exists(aws::AbstractAWSConfig, bucket, path; version::AbstractS3Vers
         s3_exists_unversioned(aws, bucket, path)
     end
 end
-s3_exists(a...; b...) = s3_exists(global_aws_config(), a...; b...)
+s3_exists(a...; kwargs...) = s3_exists(global_aws_config(), a...; kwargs...)
 
 """
     s3_delete([::AbstractAWSConfig], bucket, path; [version], kwargs...)
@@ -408,7 +408,7 @@ function s3_delete(
     return parse(S3.delete_object(bucket, path, params; aws_config=aws, kwargs...))
 end
 
-s3_delete(a...; b...) = s3_delete(global_aws_config(), a...; b...)
+s3_delete(a...; kwargs...) = s3_delete(global_aws_config(), a...; kwargs...)
 
 """
     s3_copy([::AbstractAWSConfig], bucket, path; to_bucket=bucket, to_path=path, kwargs...)
@@ -449,7 +449,7 @@ function s3_copy(
     )
 end
 
-s3_copy(a...; b...) = s3_copy(global_aws_config(), a...; b...)
+s3_copy(a...; kwargs...) = s3_copy(global_aws_config(), a...; kwargs...)
 
 """
     s3_create_bucket([::AbstractAWSConfig], bucket; kwargs...)
@@ -518,7 +518,7 @@ function s3_put_cors(aws::AbstractAWSConfig, bucket, cors_config; kwargs...)
     return parse(S3.put_bucket_cors(bucket, cors_config; aws_config=aws, kwargs...))
 end
 
-s3_put_cors(a...; b...) = s3_put_cors(AWS.global_aws_config(), a...; b...)
+s3_put_cors(a...; kwargs...) = s3_put_cors(AWS.global_aws_config(), a...; kwargs...)
 
 """
     s3_enable_versioning([::AbstractAWSConfig], bucket, [status]; kwargs...)
@@ -552,7 +552,7 @@ function s3_enable_versioning(aws::AbstractAWSConfig, bucket, status="Enabled"; 
     return parse(r)
 end
 
-s3_enable_versioning(a; b...) = s3_enable_versioning(global_aws_config(), a; b...)
+s3_enable_versioning(a; kwargs...) = s3_enable_versioning(global_aws_config(), a; kwargs...)
 
 """
     s3_put_tags([::AbstractAWSConfig], bucket, [path], tags::Dict; kwargs...)
@@ -646,7 +646,7 @@ function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     end
 end
 
-s3_get_tags(a...; b...) = s3_get_tags(global_aws_config(), a...; b...)
+s3_get_tags(a...; kwargs...) = s3_get_tags(global_aws_config(), a...; kwargs...)
 
 """
     s3_delete_tags([::AbstractAWSConfig], bucket, [path])
@@ -677,7 +677,7 @@ function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     return parse(r)
 end
 
-s3_delete_tags(a...; b...) = s3_delete_tags(global_aws_config(), a...; b...)
+s3_delete_tags(a...; kwargs...) = s3_delete_tags(global_aws_config(), a...; kwargs...)
 
 """
     s3_delete_bucket([::AbstractAWSConfig], "bucket"; kwargs...)
@@ -698,7 +698,7 @@ See also [`AWSS3.s3_nuke_bucket`](@ref).
 function s3_delete_bucket(aws::AbstractAWSConfig, bucket; kwargs...)
     return parse(S3.delete_bucket(bucket; aws_config=aws, kwargs...))
 end
-s3_delete_bucket(a; b...) = s3_delete_bucket(global_aws_config(), a; b...)
+s3_delete_bucket(a; kwargs...) = s3_delete_bucket(global_aws_config(), a; kwargs...)
 
 """
     s3_list_buckets([::AbstractAWSConfig]; kwargs...)
@@ -819,7 +819,7 @@ function s3_list_keys(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs...)
     return (o["Key"] for o in s3_list_objects(aws, bucket, path_prefix; kwargs...))
 end
 
-s3_list_keys(a...; b...) = s3_list_keys(global_aws_config(), a...; b...)
+s3_list_keys(a...; kwargs...) = s3_list_keys(global_aws_config(), a...; kwargs...)
 
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -865,7 +865,7 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     return versions
 end
 
-s3_list_versions(a...; b...) = s3_list_versions(global_aws_config(), a...; b...)
+s3_list_versions(a...; kwargs...) = s3_list_versions(global_aws_config(), a...; kwargs...)
 
 """
     s3_purge_versions([::AbstractAWSConfig], bucket, [path_prefix [, pattern]]; kwargs...)
@@ -904,7 +904,7 @@ function s3_purge_versions(
     end
 end
 
-s3_purge_versions(a...; b...) = s3_purge_versions(global_aws_config(), a...; b...)
+s3_purge_versions(a...; kwargs...) = s3_purge_versions(global_aws_config(), a...; kwargs...)
 
 """
     s3_put([::AbstractAWSConfig], bucket, path, data, data_type="", encoding="";
@@ -981,7 +981,7 @@ function s3_put(
     return parse_response ? parse(response) : response
 end
 
-s3_put(a...; b...) = s3_put(global_aws_config(), a...; b...)
+s3_put(a...; kwargs...) = s3_put(global_aws_config(), a...; kwargs...)
 
 function s3_begin_multipart_upload(
     aws::AbstractAWSConfig,
@@ -1259,7 +1259,7 @@ function s3_sign_url(
     end
 end
 
-s3_sign_url(a...; b...) = s3_sign_url(global_aws_config(), a...; b...)
+s3_sign_url(a...; kwargs...) = s3_sign_url(global_aws_config(), a...; kwargs...)
 
 """
     s3_nuke_bucket([::AbstractAWSConfig], bucket_name)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -602,10 +602,6 @@ function s3_put_tags(aws::AbstractAWSConfig, bucket, path, tags::SSDict; kwargs.
     return parse(r)
 end
 
-function s3_put_tags(aws::AbstractAWSConfig, bucket, tags::SSDict; kwargs...)
-    return s3_put_tags(aws, bucket, "", tags; kwargs...)
-end
-
 s3_put_tags(args...; kwargs...) = s3_put_tags(global_aws_config(), args...; kwargs...)
 
 """


### PR DESCRIPTION
Address #213 by updating `a...` to the list of named arguments for functions with 3 or fewer arguments.

Somewhat pedantic, but it is very easy for folks new to this library to get confusing error messages back, and this will helpfully lead to clearer error messages.