### PR TITLE
Add `s3_nuke_object`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - v0.11.0: The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
 - v0.11.1: The new keyword argument `returns` for `Base.write(fp::S3Path, ...)` determines the output returned from `write`, which can now be the raw `AWS.Response` (`returns=:response`) or the `S3Path` (`returns=:path`); this latter option returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#293]).
+- v0.11.2: Added `s3_delete_all_versions` function to delete all versions of an object ([#299])
 
 [#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289
 [#293]: https://github.com/JuliaCloud/AWSS3.jl/pull/293
+[#299]: https://github.com/JuliaCloud/AWSS3.jl/pull/299

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - v0.11.0: The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
 - v0.11.1: The new keyword argument `returns` for `Base.write(fp::S3Path, ...)` determines the output returned from `write`, which can now be the raw `AWS.Response` (`returns=:response`) or the `S3Path` (`returns=:path`); this latter option returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#293]).
-- v0.11.2: Added `s3_delete_all_versions` function to delete all versions of an object ([#299])
+- v0.11.2: Added `s3_nuke_object_versions` function to delete all versions of an object ([#299]).
 
 [#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289
 [#293]: https://github.com/JuliaCloud/AWSS3.jl/pull/293

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - v0.11.0: The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
 - v0.11.1: The new keyword argument `returns` for `Base.write(fp::S3Path, ...)` determines the output returned from `write`, which can now be the raw `AWS.Response` (`returns=:response`) or the `S3Path` (`returns=:path`); this latter option returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#293]).
-- v0.11.2: Added `s3_nuke_object_versions` function to delete all versions of an object ([#299]).
+- v0.11.2: Added `s3_nuke_object` function to delete all versions of an object ([#299]).
 
 [#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289
 [#293]: https://github.com/JuliaCloud/AWSS3.jl/pull/293

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -15,7 +15,6 @@ export S3Path,
     s3_get_file,
     s3_exists,
     s3_delete,
-    s3_delete_all_versions,
     s3_copy,
     s3_create_bucket,
     s3_put_cors,
@@ -180,7 +179,7 @@ function s3_get(
     end
 end
 
-s3_get(bucket, path; kwargs...) = s3_get(global_aws_config(), bucket, path; kwargs...)
+s3_get(a...; b...) = s3_get(global_aws_config(), a...; b...)
 
 """
     s3_get_file([::AbstractAWSConfig], bucket, path, filename; [version=], kwargs...)
@@ -205,9 +204,7 @@ function s3_get_file(
     end
 end
 
-function s3_get_file(bucket, path, filename; kwargs...)
-    return s3_get_file(global_aws_config(), bucket, path, filename; kwargs...)
-end
+s3_get_file(a...; b...) = s3_get_file(global_aws_config(), a...; b...)
 
 function s3_get_file(
     aws::AbstractAWSConfig,
@@ -260,9 +257,7 @@ function s3_get_meta(
     return Dict(r.headers)
 end
 
-function s3_get_meta(bucket, path; kwargs...)
-    return s3_get_meta(global_aws_config(), bucket, path; kwargs...)
-end
+s3_get_meta(a...; b...) = s3_get_meta(global_aws_config(), a...; b...)
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
     q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
@@ -386,7 +381,7 @@ function s3_exists(aws::AbstractAWSConfig, bucket, path; version::AbstractS3Vers
         s3_exists_unversioned(aws, bucket, path)
     end
 end
-s3_exists(bucket, path; kwargs...) = s3_exists(global_aws_config(), bucket, path; kwargs...)
+s3_exists(a...; b...) = s3_exists(global_aws_config(), a...; b...)
 
 """
     s3_delete([::AbstractAWSConfig], bucket, path; [version], kwargs...)
@@ -413,7 +408,7 @@ function s3_delete(
     return parse(S3.delete_object(bucket, path, params; aws_config=aws, kwargs...))
 end
 
-s3_delete(bucket, path; kwargs...) = s3_delete(global_aws_config(), bucket, path; kwargs...)
+s3_delete(a...; b...) = s3_delete(global_aws_config(), a...; b...)
 
 """
     s3_delete_all_versions([::AbstractAWSConfig], bucket, path; kwargs...)
@@ -491,7 +486,7 @@ function s3_copy(
     )
 end
 
-s3_copy(bucket, path; kwargs...) = s3_copy(global_aws_config(), bucket, path; kwargs...)
+s3_copy(a...; b...) = s3_copy(global_aws_config(), a...; b...)
 
 """
     s3_create_bucket([::AbstractAWSConfig], bucket; kwargs...)
@@ -560,9 +555,7 @@ function s3_put_cors(aws::AbstractAWSConfig, bucket, cors_config; kwargs...)
     return parse(S3.put_bucket_cors(bucket, cors_config; aws_config=aws, kwargs...))
 end
 
-function s3_put_cors(bucket, cors_config; kwargs...)
-    return s3_put_cors(AWS.global_aws_config(), bucket, cors_config; kwargs...)
-end
+s3_put_cors(a...; b...) = s3_put_cors(AWS.global_aws_config(), a...; b...)
 
 """
     s3_enable_versioning([::AbstractAWSConfig], bucket, [status]; kwargs...)
@@ -596,7 +589,7 @@ function s3_enable_versioning(aws::AbstractAWSConfig, bucket, status="Enabled"; 
     return parse(r)
 end
 
-s3_enable_versioning(a; kwargs...) = s3_enable_versioning(global_aws_config(), a; kwargs...)
+s3_enable_versioning(a; b...) = s3_enable_versioning(global_aws_config(), a; b...)
 
 """
     s3_put_tags([::AbstractAWSConfig], bucket, [path], tags::Dict; kwargs...)
@@ -642,12 +635,7 @@ function s3_put_tags(aws::AbstractAWSConfig, bucket, tags::SSDict; kwargs...)
     return s3_put_tags(aws, bucket, "", tags; kwargs...)
 end
 
-function s3_put_tags(bucket, path, tags; kwargs...)
-    return s3_put_tags(global_aws_config(), bucket, path, tags; kwargs...)
-end
-function s3_put_tags(bucket, tags; kwargs...)
-    return s3_put_tags(global_aws_config(), bucket, tags; kwargs...)
-end
+s3_put_tags(a...) = s3_put_tags(global_aws_config(), a...)
 
 """
     s3_get_tags([::AbstractAWSConfig], bucket, [path]; kwargs...)
@@ -695,9 +683,7 @@ function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     end
 end
 
-function s3_get_tags(bucket, path=""; kwargs...)
-    return s3_get_tags(global_aws_config(), bucket, path; kwargs...)
-end
+s3_get_tags(a...; b...) = s3_get_tags(global_aws_config(), a...; b...)
 
 """
     s3_delete_tags([::AbstractAWSConfig], bucket, [path])
@@ -728,9 +714,7 @@ function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     return parse(r)
 end
 
-function s3_delete_tags(bucket, path=""; kwargs...)
-    return s3_delete_tags(global_aws_config(), bucket, path; kwargs...)
-end
+s3_delete_tags(a...; b...) = s3_delete_tags(global_aws_config(), a...; b...)
 
 """
     s3_delete_bucket([::AbstractAWSConfig], "bucket"; kwargs...)
@@ -751,7 +735,7 @@ See also [`AWSS3.s3_nuke_bucket`](@ref).
 function s3_delete_bucket(aws::AbstractAWSConfig, bucket; kwargs...)
     return parse(S3.delete_bucket(bucket; aws_config=aws, kwargs...))
 end
-s3_delete_bucket(a; kwargs...) = s3_delete_bucket(global_aws_config(), a; kwargs...)
+s3_delete_bucket(a; b...) = s3_delete_bucket(global_aws_config(), a; b...)
 
 """
     s3_list_buckets([::AbstractAWSConfig]; kwargs...)
@@ -836,9 +820,7 @@ function s3_list_objects(
         end
     end
 end
-function s3_list_objects(bucket, path_prefix=""; kw...)
-    return s3_list_objects(global_aws_config(), bucket, path_prefix; kw...)
-end
+s3_list_objects(a...; kw...) = s3_list_objects(global_aws_config(), a...; kw...)
 
 """
     s3_directory_stat([::AbstractAWSConfig], bucket, path)
@@ -863,7 +845,7 @@ function s3_directory_stat(
     end
     return s, tmlast
 end
-s3_directory_stat(bucket, path) = s3_directory_stat(global_aws_config(), bucket, path)
+s3_directory_stat(a...) = s3_directory_stat(global_aws_config(), a...)
 
 """
     s3_list_keys([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -874,9 +856,7 @@ function s3_list_keys(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs...)
     return (o["Key"] for o in s3_list_objects(aws, bucket, path_prefix; kwargs...))
 end
 
-function s3_list_keys(bucket, path_prefix=""; kwargs...)
-    return s3_list_keys(global_aws_config(), bucket, path_prefix; kwargs...)
-end
+s3_list_keys(a...; b...) = s3_list_keys(global_aws_config(), a...; b...)
 
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -922,9 +902,7 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     return versions
 end
 
-function s3_list_versions(bucket, path_prefix=""; kwargs...)
-    return s3_list_versions(global_aws_config(), bucket, path_prefix; kwargs...)
-end
+s3_list_versions(a...; b...) = s3_list_versions(global_aws_config(), a...; b...)
 
 """
     s3_purge_versions([::AbstractAWSConfig], bucket, [path_prefix [, pattern]]; kwargs...)
@@ -963,9 +941,7 @@ function s3_purge_versions(
     end
 end
 
-function s3_purge_versions(bucket, path_prefix="", pattern=""; kwargs...)
-    return s3_purge_versions(global_aws_config(), bucket, path_prefix, pattern; kwargs...)
-end
+s3_purge_versions(a...; b...) = s3_purge_versions(global_aws_config(), a...; b...)
 
 """
     s3_put([::AbstractAWSConfig], bucket, path, data, data_type="", encoding="";
@@ -1042,7 +1018,7 @@ function s3_put(
     return parse_response ? parse(response) : response
 end
 
-s3_put(args...; kwargs...) = s3_put(global_aws_config(), args...; kwargs...)
+s3_put(a...; b...) = s3_put(global_aws_config(), a...; b...)
 
 function s3_begin_multipart_upload(
     aws::AbstractAWSConfig,
@@ -1320,7 +1296,7 @@ function s3_sign_url(
     end
 end
 
-s3_sign_url(args...; kwargs...) = s3_sign_url(global_aws_config(), args...; kwargs...)
+s3_sign_url(a...; b...) = s3_sign_url(global_aws_config(), a...; b...)
 
 """
     s3_nuke_bucket([::AbstractAWSConfig], bucket_name)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -179,7 +179,7 @@ function s3_get(
     end
 end
 
-s3_get(a...; kwargs...) = s3_get(global_aws_config(), a...; kwargs...)
+s3_get(bucket, path; kwargs...) = s3_get(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_get_file([::AbstractAWSConfig], bucket, path, filename; [version=], kwargs...)
@@ -204,7 +204,7 @@ function s3_get_file(
     end
 end
 
-s3_get_file(a...; kwargs...) = s3_get_file(global_aws_config(), a...; kwargs...)
+s3_get_file(bucket, path, filename; kwargs...) = s3_get_file(global_aws_config(), bucket, path, filename; kwargs...)
 
 function s3_get_file(
     aws::AbstractAWSConfig,
@@ -257,7 +257,7 @@ function s3_get_meta(
     return Dict(r.headers)
 end
 
-s3_get_meta(a...; kwargs...) = s3_get_meta(global_aws_config(), a...; kwargs...)
+s3_get_meta(bucket, path; kwargs...) = s3_get_meta(global_aws_config(), bucket, path; kwargs...)
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
     q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
@@ -381,7 +381,7 @@ function s3_exists(aws::AbstractAWSConfig, bucket, path; version::AbstractS3Vers
         s3_exists_unversioned(aws, bucket, path)
     end
 end
-s3_exists(a...; kwargs...) = s3_exists(global_aws_config(), a...; kwargs...)
+s3_exists(bucket, path; kwargs...) = s3_exists(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_delete([::AbstractAWSConfig], bucket, path; [version], kwargs...)
@@ -408,7 +408,7 @@ function s3_delete(
     return parse(S3.delete_object(bucket, path, params; aws_config=aws, kwargs...))
 end
 
-s3_delete(a...; kwargs...) = s3_delete(global_aws_config(), a...; kwargs...)
+s3_delete(bucket, path; kwargs...) = s3_delete(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_copy([::AbstractAWSConfig], bucket, path; to_bucket=bucket, to_path=path, kwargs...)
@@ -449,7 +449,7 @@ function s3_copy(
     )
 end
 
-s3_copy(a...; kwargs...) = s3_copy(global_aws_config(), a...; kwargs...)
+s3_copy(bucket, path; kwargs...) = s3_copy(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_create_bucket([::AbstractAWSConfig], bucket; kwargs...)
@@ -518,7 +518,7 @@ function s3_put_cors(aws::AbstractAWSConfig, bucket, cors_config; kwargs...)
     return parse(S3.put_bucket_cors(bucket, cors_config; aws_config=aws, kwargs...))
 end
 
-s3_put_cors(a...; kwargs...) = s3_put_cors(AWS.global_aws_config(), a...; kwargs...)
+s3_put_cors(bucket, cors_config; kwargs...) = s3_put_cors(AWS.global_aws_config(), bucket, cors_config; kwargs...)
 
 """
     s3_enable_versioning([::AbstractAWSConfig], bucket, [status]; kwargs...)
@@ -598,7 +598,8 @@ function s3_put_tags(aws::AbstractAWSConfig, bucket, tags::SSDict; kwargs...)
     return s3_put_tags(aws, bucket, "", tags; kwargs...)
 end
 
-s3_put_tags(a...) = s3_put_tags(global_aws_config(), a...)
+s3_put_tags(bucket, path, tags; kwargs...) = s3_put_tags(global_aws_config(), bucket, path, tags; kwargs...)
+s3_put_tags(bucket, tags; kwargs...) = s3_put_tags(global_aws_config(), bucket, tags; kwargs...)
 
 """
     s3_get_tags([::AbstractAWSConfig], bucket, [path]; kwargs...)
@@ -646,7 +647,7 @@ function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     end
 end
 
-s3_get_tags(a...; kwargs...) = s3_get_tags(global_aws_config(), a...; kwargs...)
+s3_get_tags(bucket, path=""; kwargs...) = s3_get_tags(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_delete_tags([::AbstractAWSConfig], bucket, [path])
@@ -677,7 +678,7 @@ function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     return parse(r)
 end
 
-s3_delete_tags(a...; kwargs...) = s3_delete_tags(global_aws_config(), a...; kwargs...)
+s3_delete_tags(bucket, path=""; kwargs...) = s3_delete_tags(global_aws_config(), bucket, path; kwargs...)
 
 """
     s3_delete_bucket([::AbstractAWSConfig], "bucket"; kwargs...)
@@ -783,7 +784,7 @@ function s3_list_objects(
         end
     end
 end
-s3_list_objects(a...; kw...) = s3_list_objects(global_aws_config(), a...; kw...)
+s3_list_objects(bucket, path_prefix=""; kw...) = s3_list_objects(global_aws_config(), bucket, path_prefix; kw...)
 
 """
     s3_directory_stat([::AbstractAWSConfig], bucket, path)
@@ -808,7 +809,7 @@ function s3_directory_stat(
     end
     return s, tmlast
 end
-s3_directory_stat(a...) = s3_directory_stat(global_aws_config(), a...)
+s3_directory_stat(bucket, path) = s3_directory_stat(global_aws_config(), bucket, path)
 
 """
     s3_list_keys([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -819,7 +820,7 @@ function s3_list_keys(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs...)
     return (o["Key"] for o in s3_list_objects(aws, bucket, path_prefix; kwargs...))
 end
 
-s3_list_keys(a...; kwargs...) = s3_list_keys(global_aws_config(), a...; kwargs...)
+s3_list_keys(bucket, path_prefix=""; kwargs...) = s3_list_keys(global_aws_config(), bucket, path_prefix; kwargs...)
 
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -865,7 +866,7 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     return versions
 end
 
-s3_list_versions(a...; kwargs...) = s3_list_versions(global_aws_config(), a...; kwargs...)
+s3_list_versions(bucket, path_prefix=""; kwargs...) = s3_list_versions(global_aws_config(), bucket, path_prefix; kwargs...)
 
 """
     s3_purge_versions([::AbstractAWSConfig], bucket, [path_prefix [, pattern]]; kwargs...)
@@ -904,7 +905,7 @@ function s3_purge_versions(
     end
 end
 
-s3_purge_versions(a...; kwargs...) = s3_purge_versions(global_aws_config(), a...; kwargs...)
+s3_purge_versions(bucket, path_prefix="", pattern=""; kwargs...) = s3_purge_versions(global_aws_config(), bucket, path_prefix, pattern; kwargs...)
 
 """
     s3_put([::AbstractAWSConfig], bucket, path, data, data_type="", encoding="";
@@ -981,7 +982,7 @@ function s3_put(
     return parse_response ? parse(response) : response
 end
 
-s3_put(a...; kwargs...) = s3_put(global_aws_config(), a...; kwargs...)
+s3_put(args...; kwargs...) = s3_put(global_aws_config(), args...; kwargs...)
 
 function s3_begin_multipart_upload(
     aws::AbstractAWSConfig,
@@ -1259,7 +1260,7 @@ function s3_sign_url(
     end
 end
 
-s3_sign_url(a...; kwargs...) = s3_sign_url(global_aws_config(), a...; kwargs...)
+s3_sign_url(args...; kwargs...) = s3_sign_url(global_aws_config(), args...; kwargs...)
 
 """
     s3_nuke_bucket([::AbstractAWSConfig], bucket_name)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -414,9 +414,9 @@ s3_delete(a...; b...) = s3_delete(global_aws_config(), a...; b...)
 """
     s3_nuke_object_versions([::AbstractAWSConfig], bucket, path; kwargs...)
 
-Deletes all versions of object `path` from `bucket`, forwarding all `kwargs` to the
-internal per-version [`s3_delete`](@ref) call. In the case of an error, any versions
-already deleted will be lost.
+Deletes all versions of object `path` from `bucket`. All provided `kwargs` are forwarded to
+[`s3_delete`](@ref). In the event an error occurs any object versions already deleted by
+`s3_nuke_object_versions` will be lost.
 
 To only delete one specific version, see [`s3_delete`](@ref); to delete all versions
 EXCEPT the latest version, see [`s3_purge_versions`](@ref); to delete all versions

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -417,8 +417,11 @@ s3_delete(bucket, path; kwargs...) = s3_delete(global_aws_config(), bucket, path
 """
     s3_delete_all_versions([::AbstractAWSConfig], bucket, path; kwargs...)
 
-Deletes all versions of an object from a bucket; forwards all `kwargs` to internal
-[`s3_delete`](@ref) call.
+Deletes all versions of object `path` from `bucket`, forwarding all `kwargs` to the
+internal per-version [`s3_delete`](@ref) call.
+
+To only delete one specific version, see [`s3_delete`](@ref); to delete all versions
+EXCEPT the latest version, see [`s3_purge_versions`](@ref).
 
 # API Calls
 

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -24,7 +24,7 @@ export S3Path,
     s3_list_objects,
     s3_list_keys,
     s3_list_versions,
-    s3_nuke_object_versions,
+    s3_nuke_object,
     s3_get_meta,
     s3_directory_stat,
     s3_purge_versions,
@@ -412,11 +412,11 @@ end
 s3_delete(a...; b...) = s3_delete(global_aws_config(), a...; b...)
 
 """
-    s3_nuke_object_versions([::AbstractAWSConfig], bucket, path; kwargs...)
+    s3_nuke_object([::AbstractAWSConfig], bucket, path; kwargs...)
 
 Deletes all versions of object `path` from `bucket`. All provided `kwargs` are forwarded to
 [`s3_delete`](@ref). In the event an error occurs any object versions already deleted by
-`s3_nuke_object_versions` will be lost.
+`s3_nuke_object` will be lost.
 
 To only delete one specific version, use [`s3_delete`](@ref); to delete all versions
 EXCEPT the latest version, use [`s3_purge_versions`](@ref); to delete all versions
@@ -432,7 +432,7 @@ in an entire bucket, use [`AWSS3.s3_nuke_bucket`](@ref).
 - [`s3:DeleteObject`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-DeleteObject)
 - [`s3:ListBucketVersions`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-ListBucketVersions)
 """
-function s3_nuke_object_versions(aws::AbstractAWSConfig, bucket, path; kwargs...)
+function s3_nuke_object(aws::AbstractAWSConfig, bucket, path; kwargs...)
     # Because list_versions returns ALL keys with the given _prefix_, we need to
     # restrict the results to ones with the _exact same_ key.
     for object in s3_list_versions(aws, bucket, path)
@@ -448,8 +448,8 @@ function s3_nuke_object_versions(aws::AbstractAWSConfig, bucket, path; kwargs...
     return nothing
 end
 
-function s3_nuke_object_versions(bucket, path; kwargs...)
-    return s3_nuke_object_versions(global_aws_config(), bucket, path; kwargs...)
+function s3_nuke_object(bucket, path; kwargs...)
+    return s3_nuke_object(global_aws_config(), bucket, path; kwargs...)
 end
 
 """

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -437,9 +437,7 @@ EXCEPT the latest version, see [`s3_purge_versions`](@ref).
 function s3_delete_all_versions(aws::AbstractAWSConfig, bucket, path; kwargs...)
     # Because list_versions returns ALL keys with the given _prefix_, we need to
     # restrict the results to ones with the _exact same_ key.
-    versions = [
-        x["VersionId"] for x in s3_list_versions(bucket, path) if x["Key"] == path
-    ]
+    versions = [x["VersionId"] for x in s3_list_versions(bucket, path) if x["Key"] == path]
     for version in versions
         try
             s3_delete(bucket, path; version, kwargs...)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -179,7 +179,7 @@ function s3_get(
     end
 end
 
-s3_get(a...; b...) = s3_get(global_aws_config(), a...; b...)
+s3_get(a...; kwargs...) = s3_get(global_aws_config(), a...; kwargs...)
 
 """
     s3_get_file([::AbstractAWSConfig], bucket, path, filename; [version=], kwargs...)
@@ -204,7 +204,7 @@ function s3_get_file(
     end
 end
 
-s3_get_file(a...; b...) = s3_get_file(global_aws_config(), a...; b...)
+s3_get_file(a...; kwargs...) = s3_get_file(global_aws_config(), a...; kwargs...)
 
 function s3_get_file(
     aws::AbstractAWSConfig,
@@ -257,7 +257,7 @@ function s3_get_meta(
     return Dict(r.headers)
 end
 
-s3_get_meta(a...; b...) = s3_get_meta(global_aws_config(), a...; b...)
+s3_get_meta(a...; kwargs...) = s3_get_meta(global_aws_config(), a...; kwargs...)
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
     q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
@@ -381,7 +381,7 @@ function s3_exists(aws::AbstractAWSConfig, bucket, path; version::AbstractS3Vers
         s3_exists_unversioned(aws, bucket, path)
     end
 end
-s3_exists(a...; b...) = s3_exists(global_aws_config(), a...; b...)
+s3_exists(a...; kwargs...) = s3_exists(global_aws_config(), a...; kwargs...)
 
 """
     s3_delete([::AbstractAWSConfig], bucket, path; [version], kwargs...)
@@ -408,7 +408,7 @@ function s3_delete(
     return parse(S3.delete_object(bucket, path, params; aws_config=aws, kwargs...))
 end
 
-s3_delete(a...; b...) = s3_delete(global_aws_config(), a...; b...)
+s3_delete(a...; kwargs...) = s3_delete(global_aws_config(), a...; kwargs...)
 
 """
     s3_copy([::AbstractAWSConfig], bucket, path; to_bucket=bucket, to_path=path, kwargs...)
@@ -449,7 +449,7 @@ function s3_copy(
     )
 end
 
-s3_copy(a...; b...) = s3_copy(global_aws_config(), a...; b...)
+s3_copy(a...; kwargs...) = s3_copy(global_aws_config(), a...; kwargs...)
 
 """
     s3_create_bucket([::AbstractAWSConfig], bucket; kwargs...)
@@ -518,7 +518,7 @@ function s3_put_cors(aws::AbstractAWSConfig, bucket, cors_config; kwargs...)
     return parse(S3.put_bucket_cors(bucket, cors_config; aws_config=aws, kwargs...))
 end
 
-s3_put_cors(a...; b...) = s3_put_cors(AWS.global_aws_config(), a...; b...)
+s3_put_cors(a...; kwargs...) = s3_put_cors(AWS.global_aws_config(), a...; kwargs...)
 
 """
     s3_enable_versioning([::AbstractAWSConfig], bucket, [status]; kwargs...)
@@ -552,7 +552,7 @@ function s3_enable_versioning(aws::AbstractAWSConfig, bucket, status="Enabled"; 
     return parse(r)
 end
 
-s3_enable_versioning(a; b...) = s3_enable_versioning(global_aws_config(), a; b...)
+s3_enable_versioning(a; kwargs...) = s3_enable_versioning(global_aws_config(), a; kwargs...)
 
 """
     s3_put_tags([::AbstractAWSConfig], bucket, [path], tags::Dict; kwargs...)
@@ -646,7 +646,7 @@ function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     end
 end
 
-s3_get_tags(a...; b...) = s3_get_tags(global_aws_config(), a...; b...)
+s3_get_tags(a...; kwargs...) = s3_get_tags(global_aws_config(), a...; kwargs...)
 
 """
     s3_delete_tags([::AbstractAWSConfig], bucket, [path])
@@ -677,7 +677,7 @@ function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     return parse(r)
 end
 
-s3_delete_tags(a...; b...) = s3_delete_tags(global_aws_config(), a...; b...)
+s3_delete_tags(a...; kwargs...) = s3_delete_tags(global_aws_config(), a...; kwargs...)
 
 """
     s3_delete_bucket([::AbstractAWSConfig], "bucket"; kwargs...)
@@ -698,7 +698,7 @@ See also [`AWSS3.s3_nuke_bucket`](@ref).
 function s3_delete_bucket(aws::AbstractAWSConfig, bucket; kwargs...)
     return parse(S3.delete_bucket(bucket; aws_config=aws, kwargs...))
 end
-s3_delete_bucket(a; b...) = s3_delete_bucket(global_aws_config(), a; b...)
+s3_delete_bucket(a; kwargs...) = s3_delete_bucket(global_aws_config(), a; kwargs...)
 
 """
     s3_list_buckets([::AbstractAWSConfig]; kwargs...)
@@ -819,7 +819,7 @@ function s3_list_keys(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs...)
     return (o["Key"] for o in s3_list_objects(aws, bucket, path_prefix; kwargs...))
 end
 
-s3_list_keys(a...; b...) = s3_list_keys(global_aws_config(), a...; b...)
+s3_list_keys(a...; kwargs...) = s3_list_keys(global_aws_config(), a...; kwargs...)
 
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -865,7 +865,7 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     return versions
 end
 
-s3_list_versions(a...; b...) = s3_list_versions(global_aws_config(), a...; b...)
+s3_list_versions(a...; kwargs...) = s3_list_versions(global_aws_config(), a...; kwargs...)
 
 """
     s3_purge_versions([::AbstractAWSConfig], bucket, [path_prefix [, pattern]]; kwargs...)
@@ -904,7 +904,7 @@ function s3_purge_versions(
     end
 end
 
-s3_purge_versions(a...; b...) = s3_purge_versions(global_aws_config(), a...; b...)
+s3_purge_versions(a...; kwargs...) = s3_purge_versions(global_aws_config(), a...; kwargs...)
 
 """
     s3_put([::AbstractAWSConfig], bucket, path, data, data_type="", encoding="";
@@ -981,7 +981,7 @@ function s3_put(
     return parse_response ? parse(response) : response
 end
 
-s3_put(a...; b...) = s3_put(global_aws_config(), a...; b...)
+s3_put(a...; kwargs...) = s3_put(global_aws_config(), a...; kwargs...)
 
 function s3_begin_multipart_upload(
     aws::AbstractAWSConfig,
@@ -1259,7 +1259,7 @@ function s3_sign_url(
     end
 end
 
-s3_sign_url(a...; b...) = s3_sign_url(global_aws_config(), a...; b...)
+s3_sign_url(a...; kwargs...) = s3_sign_url(global_aws_config(), a...; kwargs...)
 
 """
     s3_nuke_bucket([::AbstractAWSConfig], bucket_name)

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -24,6 +24,7 @@ export S3Path,
     s3_list_objects,
     s3_list_keys,
     s3_list_versions,
+    s3_nuke_object_versions,
     s3_get_meta,
     s3_directory_stat,
     s3_purge_versions,
@@ -411,13 +412,14 @@ end
 s3_delete(a...; b...) = s3_delete(global_aws_config(), a...; b...)
 
 """
-    s3_delete_all_versions([::AbstractAWSConfig], bucket, path; kwargs...)
+    s3_nuke_object_versions([::AbstractAWSConfig], bucket, path; kwargs...)
 
 Deletes all versions of object `path` from `bucket`, forwarding all `kwargs` to the
 internal per-version [`s3_delete`](@ref) call.
 
 To only delete one specific version, see [`s3_delete`](@ref); to delete all versions
-EXCEPT the latest version, see [`s3_purge_versions`](@ref).
+EXCEPT the latest version, see [`s3_purge_versions`](@ref); to delete all versions
+in an entire bucket, see [`AWSS3.s3_nuke_bucket`](@ref).
 
 # API Calls
 
@@ -429,7 +431,7 @@ EXCEPT the latest version, see [`s3_purge_versions`](@ref).
 - [`s3:DeleteObject`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-DeleteObject)
 - [`s3:ListBucketVersions`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-ListBucketVersions)
 """
-function s3_delete_all_versions(aws::AbstractAWSConfig, bucket, path; kwargs...)
+function s3_nuke_object_versions(aws::AbstractAWSConfig, bucket, path; kwargs...)
     # Because list_versions returns ALL keys with the given _prefix_, we need to
     # restrict the results to ones with the _exact same_ key.
     for object in s3_list_versions(aws, bucket, path)
@@ -446,8 +448,8 @@ function s3_delete_all_versions(aws::AbstractAWSConfig, bucket, path; kwargs...)
     return nothing
 end
 
-function s3_delete_all_versions(bucket, path; kwargs...)
-    return s3_delete_all_versions(global_aws_config(), bucket, path; kwargs...)
+function s3_nuke_object_versions(bucket, path; kwargs...)
+    return s3_nuke_object_versions(global_aws_config(), bucket, path; kwargs...)
 end
 
 """

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -418,9 +418,9 @@ Deletes all versions of object `path` from `bucket`. All provided `kwargs` are f
 [`s3_delete`](@ref). In the event an error occurs any object versions already deleted by
 `s3_nuke_object_versions` will be lost.
 
-To only delete one specific version, see [`s3_delete`](@ref); to delete all versions
-EXCEPT the latest version, see [`s3_purge_versions`](@ref); to delete all versions
-in an entire bucket, see [`AWSS3.s3_nuke_bucket`](@ref).
+To only delete one specific version, use [`s3_delete`](@ref); to delete all versions
+EXCEPT the latest version, use [`s3_purge_versions`](@ref); to delete all versions
+in an entire bucket, use [`AWSS3.s3_nuke_bucket`](@ref).
 
 # API Calls
 

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -432,12 +432,13 @@ EXCEPT the latest version, see [`s3_purge_versions`](@ref).
 function s3_delete_all_versions(aws::AbstractAWSConfig, bucket, path; kwargs...)
     # Because list_versions returns ALL keys with the given _prefix_, we need to
     # restrict the results to ones with the _exact same_ key.
-    versions = [x["VersionId"] for x in s3_list_versions(bucket, path) if x["Key"] == path]
-    for version in versions
+    for object in s3_list_versions(aws, bucket, path)
+        object["Key"] == path || continue
+        version = object["VersionId"]
         try
-            s3_delete(bucket, path; version, kwargs...)
+            s3_delete(aws, bucket, path; version, kwargs...)
         catch e
-            @error "Error deleting version $(version) of $(path)\n\n$(e)"
+            @error "Error deleting version $(version) of $(path)" exception=(e, catch_backtrace())
         end
     end
     return nothing

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -204,7 +204,9 @@ function s3_get_file(
     end
 end
 
-s3_get_file(bucket, path, filename; kwargs...) = s3_get_file(global_aws_config(), bucket, path, filename; kwargs...)
+function s3_get_file(bucket, path, filename; kwargs...)
+    return s3_get_file(global_aws_config(), bucket, path, filename; kwargs...)
+end
 
 function s3_get_file(
     aws::AbstractAWSConfig,
@@ -257,7 +259,9 @@ function s3_get_meta(
     return Dict(r.headers)
 end
 
-s3_get_meta(bucket, path; kwargs...) = s3_get_meta(global_aws_config(), bucket, path; kwargs...)
+function s3_get_meta(bucket, path; kwargs...)
+    return s3_get_meta(global_aws_config(), bucket, path; kwargs...)
+end
 
 function _s3_exists_file(aws::AbstractAWSConfig, bucket, path)
     q = Dict("prefix" => path, "delimiter" => "/", "max-keys" => 1)
@@ -438,8 +442,9 @@ function s3_delete_all_versions(aws::AbstractAWSConfig, bucket, path; kwargs...)
     return nothing
 end
 
-s3_delete_all_versions(bucket, path; kwargs...) = s3_delete_all_versions(global_aws_config(), bucket, path; kwargs...)
-
+function s3_delete_all_versions(bucket, path; kwargs...)
+    return s3_delete_all_versions(global_aws_config(), bucket, path; kwargs...)
+end
 
 """
     s3_copy([::AbstractAWSConfig], bucket, path; to_bucket=bucket, to_path=path, kwargs...)
@@ -549,7 +554,9 @@ function s3_put_cors(aws::AbstractAWSConfig, bucket, cors_config; kwargs...)
     return parse(S3.put_bucket_cors(bucket, cors_config; aws_config=aws, kwargs...))
 end
 
-s3_put_cors(bucket, cors_config; kwargs...) = s3_put_cors(AWS.global_aws_config(), bucket, cors_config; kwargs...)
+function s3_put_cors(bucket, cors_config; kwargs...)
+    return s3_put_cors(AWS.global_aws_config(), bucket, cors_config; kwargs...)
+end
 
 """
     s3_enable_versioning([::AbstractAWSConfig], bucket, [status]; kwargs...)
@@ -629,8 +636,12 @@ function s3_put_tags(aws::AbstractAWSConfig, bucket, tags::SSDict; kwargs...)
     return s3_put_tags(aws, bucket, "", tags; kwargs...)
 end
 
-s3_put_tags(bucket, path, tags; kwargs...) = s3_put_tags(global_aws_config(), bucket, path, tags; kwargs...)
-s3_put_tags(bucket, tags; kwargs...) = s3_put_tags(global_aws_config(), bucket, tags; kwargs...)
+function s3_put_tags(bucket, path, tags; kwargs...)
+    return s3_put_tags(global_aws_config(), bucket, path, tags; kwargs...)
+end
+function s3_put_tags(bucket, tags; kwargs...)
+    return s3_put_tags(global_aws_config(), bucket, tags; kwargs...)
+end
 
 """
     s3_get_tags([::AbstractAWSConfig], bucket, [path]; kwargs...)
@@ -678,7 +689,9 @@ function s3_get_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     end
 end
 
-s3_get_tags(bucket, path=""; kwargs...) = s3_get_tags(global_aws_config(), bucket, path; kwargs...)
+function s3_get_tags(bucket, path=""; kwargs...)
+    return s3_get_tags(global_aws_config(), bucket, path; kwargs...)
+end
 
 """
     s3_delete_tags([::AbstractAWSConfig], bucket, [path])
@@ -709,7 +722,9 @@ function s3_delete_tags(aws::AbstractAWSConfig, bucket, path=""; kwargs...)
     return parse(r)
 end
 
-s3_delete_tags(bucket, path=""; kwargs...) = s3_delete_tags(global_aws_config(), bucket, path; kwargs...)
+function s3_delete_tags(bucket, path=""; kwargs...)
+    return s3_delete_tags(global_aws_config(), bucket, path; kwargs...)
+end
 
 """
     s3_delete_bucket([::AbstractAWSConfig], "bucket"; kwargs...)
@@ -815,7 +830,9 @@ function s3_list_objects(
         end
     end
 end
-s3_list_objects(bucket, path_prefix=""; kw...) = s3_list_objects(global_aws_config(), bucket, path_prefix; kw...)
+function s3_list_objects(bucket, path_prefix=""; kw...)
+    return s3_list_objects(global_aws_config(), bucket, path_prefix; kw...)
+end
 
 """
     s3_directory_stat([::AbstractAWSConfig], bucket, path)
@@ -851,7 +868,9 @@ function s3_list_keys(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs...)
     return (o["Key"] for o in s3_list_objects(aws, bucket, path_prefix; kwargs...))
 end
 
-s3_list_keys(bucket, path_prefix=""; kwargs...) = s3_list_keys(global_aws_config(), bucket, path_prefix; kwargs...)
+function s3_list_keys(bucket, path_prefix=""; kwargs...)
+    return s3_list_keys(global_aws_config(), bucket, path_prefix; kwargs...)
+end
 
 """
     s3_list_versions([::AbstractAWSConfig], bucket, [path_prefix]; kwargs...)
@@ -897,7 +916,9 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     return versions
 end
 
-s3_list_versions(bucket, path_prefix=""; kwargs...) = s3_list_versions(global_aws_config(), bucket, path_prefix; kwargs...)
+function s3_list_versions(bucket, path_prefix=""; kwargs...)
+    return s3_list_versions(global_aws_config(), bucket, path_prefix; kwargs...)
+end
 
 """
     s3_purge_versions([::AbstractAWSConfig], bucket, [path_prefix [, pattern]]; kwargs...)
@@ -936,7 +957,9 @@ function s3_purge_versions(
     end
 end
 
-s3_purge_versions(bucket, path_prefix="", pattern=""; kwargs...) = s3_purge_versions(global_aws_config(), bucket, path_prefix, pattern; kwargs...)
+function s3_purge_versions(bucket, path_prefix="", pattern=""; kwargs...)
+    return s3_purge_versions(global_aws_config(), bucket, path_prefix, pattern; kwargs...)
+end
 
 """
     s3_put([::AbstractAWSConfig], bucket, path, data, data_type="", encoding="";

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -438,7 +438,9 @@ function s3_delete_all_versions(aws::AbstractAWSConfig, bucket, path; kwargs...)
         try
             s3_delete(aws, bucket, path; version, kwargs...)
         catch e
-            @error "Error deleting version $(version) of $(path)" exception=(e, catch_backtrace())
+            @error "Error deleting version $(version) of $(path)" exception = (
+                e, catch_backtrace()
+            )
         end
     end
     return nothing

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -463,8 +463,18 @@ function Base.rm(fp::S3Path; recursive=false, kwargs...)
     end
 
     @debug "delete: $fp"
-    return s3_delete(get_config(fp), fp.bucket, fp.key; fp.version)
+    return s3_delete(fp)
 end
+
+s3_delete(fp::S3Path) = s3_delete(get_config(fp), fp.bucket, fp.key; fp.version)
+
+"""
+    s3_delete_all_versions(fp::S3Path)
+
+Delete all versions of an object `fp`.
+"""
+s3_delete_all_versions(fp::S3Path) = s3_delete_all_versions(get_config(fp), fp.bucket, fp.key)
+
 
 # We need to special case sync with S3Paths because of how directories
 # are handled again.

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -469,12 +469,12 @@ end
 s3_delete(fp::S3Path) = s3_delete(get_config(fp), fp.bucket, fp.key; fp.version)
 
 """
-    s3_delete_all_versions(fp::S3Path)
+    s3_nuke_object_versions(fp::S3Path)
 
 Delete all versions of an object `fp`.
 """
-function s3_delete_all_versions(fp::S3Path)
-    return s3_delete_all_versions(get_config(fp), fp.bucket, fp.key)
+function s3_nuke_object_versions(fp::S3Path)
+    return s3_nuke_object_versions(get_config(fp), fp.bucket, fp.key)
 end
 
 # We need to special case sync with S3Paths because of how directories

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -469,12 +469,12 @@ end
 s3_delete(fp::S3Path) = s3_delete(get_config(fp), fp.bucket, fp.key; fp.version)
 
 """
-    s3_nuke_object_versions(fp::S3Path)
+    s3_nuke_object(fp::S3Path)
 
 Delete all versions of an object `fp`.
 """
-function s3_nuke_object_versions(fp::S3Path)
-    return s3_nuke_object_versions(get_config(fp), fp.bucket, fp.key)
+function s3_nuke_object(fp::S3Path)
+    return s3_nuke_object(get_config(fp), fp.bucket, fp.key)
 end
 
 # We need to special case sync with S3Paths because of how directories

--- a/src/s3path.jl
+++ b/src/s3path.jl
@@ -473,8 +473,9 @@ s3_delete(fp::S3Path) = s3_delete(get_config(fp), fp.bucket, fp.key; fp.version)
 
 Delete all versions of an object `fp`.
 """
-s3_delete_all_versions(fp::S3Path) = s3_delete_all_versions(get_config(fp), fp.bucket, fp.key)
-
+function s3_delete_all_versions(fp::S3Path)
+    return s3_delete_all_versions(get_config(fp), fp.bucket, fp.key)
+end
 
 # We need to special case sync with S3Paths because of how directories
 # are handled again.

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -376,10 +376,8 @@ function awss3_tests(base_config)
 
         s3_nuke_object_versions(config, bucket_name, key_to_delete)
         @test length(_s3_object_versions(config, bucket_name, key_to_delete)) == 0
-        @test !s3_exists(config, bucket_name, key_to_delete)
 
         # Test that _only_ specific path was deleted---not paths at the same prefix
-        @test s3_exists(config, bucket_name, key_not_to_delete)
         @test length(_s3_object_versions(config, bucket_name, key_not_to_delete)) == 2
     end
 

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -374,7 +374,7 @@ function awss3_tests(base_config)
         @test length(_s3_object_versions(config, bucket_name, key_to_delete)) == 3
         @test length(_s3_object_versions(config, bucket_name, key_not_to_delete)) == 2
 
-        s3_nuke_object_versions(config, bucket_name, key_to_delete)
+        s3_nuke_object(config, bucket_name, key_to_delete)
         @test length(_s3_object_versions(config, bucket_name, key_to_delete)) == 0
 
         # Test that _only_ specific path was deleted---not paths at the same prefix

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -371,7 +371,7 @@ function awss3_tests(base_config)
             x["Key"] == key_to_delete
         ]) == 3
 
-        s3_delete_all_versions(config, bucket_name, key_to_delete)
+        s3_nuke_object_versions(config, bucket_name, key_to_delete)
         @test length([
             x for x in s3_list_versions(config, bucket_name, key_to_delete) if
             x["Key"] == key_to_delete

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -356,26 +356,31 @@ function awss3_tests(base_config)
 
     is_aws(base_config) && @testset "Delete All Versions" begin
         config = assume_testset_role("DeleteAllVersionsTestset"; base_config)
+        key_to_delete = "DeleteAllVersionsTestset_key"
+        key_not_to_delete = "DeleteAllVersionsTestset_key/rad"
 
-        s3_put(config, bucket_name, "DeleteAllVersionsTestset_key", "foo.v1")
-        s3_put(config, bucket_name, "DeleteAllVersionsTestset_key", "foo.v2")
-        s3_put(config, bucket_name, "DeleteAllVersionsTestset_key", "foo.v3")
-        s3_put(config, bucket_name, "DeleteAllVersionsTestset_key/rad", "rad.v1")
-        s3_put(config, bucket_name, "DeleteAllVersionsTestset_key/rad", "rad.v2")
+        s3_put(config, bucket_name, key_to_delete, "foo.v1")
+        s3_put(config, bucket_name, key_to_delete, "foo.v2")
+        s3_put(config, bucket_name, key_to_delete, "foo.v3")
+        s3_put(config, bucket_name, key_not_to_delete, "rad.v1")
+        s3_put(config, bucket_name, key_not_to_delete, "rad.v2")
 
-        @test length(
-            s3_list_versions(config, bucket_name, "DeleteAllVersionsTestset_key")
-        ) == 3
-        @test length(s3_list_keys(config, bucket_name, "DeleteAllVersionsTestset_key")) == 2
+        @test length(s3_list_versions(config, bucket_name, key_not_to_delete)) == 5
+        @test length([
+            x for x in s3_list_versions(config, bucket_name, key_to_delete) if
+            x["Key"] == key_to_delete
+        ]) == 3
 
-        s3_delete_all_versions(config, bucket_name, "DeleteAllVersionsTestset_key")
-        @test !s3_exists(config, bucket_name, "DeleteAllVersionsTestset_key")
+        s3_delete_all_versions(config, bucket_name, key_to_delete)
+        @test length([
+            x for x in s3_list_versions(config, bucket_name, key_to_delete) if
+            x["Key"] == key_to_delete
+        ]) == 0
+        @test !s3_exists(config, bucket_name, key_to_delete)
 
         # Test that _only_ specific path was deleted---not paths at the same prefix
-        @test !s3_exists(config, bucket_name, "DeleteAllVersionsTestset_key/rad")
-        @test length(
-            s3_list_versions(config, bucket_name, "DeleteAllVersionsTestset_key/rad")
-        ) == 2
+        @test s3_exists(config, bucket_name, key_not_to_delete)
+        @test length(s3_list_versions(config, bucket_name, key_not_to_delete)) == 2
     end
 
     if is_aws(base_config)

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -355,11 +355,11 @@ function awss3_tests(base_config)
     end
 
     is_aws(base_config) && @testset "Delete All Versions" begin
-        config = assume_testset_role("DeleteAllVersionsTestset"; base_config)
-        key_to_delete = "DeleteAllVersionsTestset_key"
+        config = assume_testset_role("NukeObjectTestset"; base_config)
+        key_to_delete = "NukeObjectTestset_key"
         # Test that object that starts with the same prefix as `key_to_delete` is
         # not _also_ deleted
-        key_not_to_delete = "DeleteAllVersionsTestset_key/rad"
+        key_not_to_delete = "NukeObjectTestset_key/rad"
 
         function _s3_object_versions(config, bucket, key)
             return filter!(x -> x["Key"] == key, s3_list_versions(config, bucket, key))

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -236,10 +236,10 @@ Resources:
               - s3:DeleteObjectVersion
             Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
 
-  DeleteAllVersionsTestsetRole:
+  NukeObjectTestsetRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${GitHubRepo}-DeleteAllVersionsTestset
+      RoleName: !Sub ${GitHubRepo}-NukeObjectTestset
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -248,12 +248,12 @@ Resources:
               AWS: !GetAtt PublicCIRole.Arn
             Action: sts:AssumeRole
 
-  DeleteAllVersionsTestsetPolicy:
+  NukeObjectTestsetPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub ${GitHubRepo}-DeleteAllVersionsTestset
+      PolicyName: !Sub ${GitHubRepo}-NukeObjectTestset
       Roles:
-        - !Ref DeleteAllVersionsTestsetRole
+        - !Ref NukeObjectTestsetRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/test/resources/awss3_jl_test.yaml
+++ b/test/resources/awss3_jl_test.yaml
@@ -236,6 +236,38 @@ Resources:
               - s3:DeleteObjectVersion
             Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
 
+  DeleteAllVersionsTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-DeleteAllVersionsTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  DeleteAllVersionsTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-DeleteAllVersionsTestset
+      Roles:
+        - !Ref DeleteAllVersionsTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucketVersions
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:DeleteObjectVersion
+              - s3:PutObject
+            Resource: !Sub arn:aws:s3:::${BucketPrefix}*/*
+
   RestrictedPrefixTestsetRole:
     Type: AWS::IAM::Role
     Properties:

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -699,7 +699,7 @@ function s3path_tests(base_config)
             @test !exists(versioned_path)
             @test length(s3_list_versions(config, bucket_name, key)) == 1
 
-            fp = S3Path(bucket_name, "test_versions_deleteall"; config)
+            fp = S3Path(bucket_name, "test_versions_nukeobject"; config)
             foreach(_ -> write(fp, "foo"), 1:6)
             @test length(s3_list_versions(fp.config, fp.bucket, fp.key)) == 6
             s3_nuke_object(fp)

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -698,6 +698,13 @@ function s3path_tests(base_config)
             rm(versioned_path)
             @test !exists(versioned_path)
             @test length(s3_list_versions(config, bucket_name, key)) == 1
+
+            fp = S3Path(config, bucket_name, "test_versions_deleteall")
+            foreach(_ -> write(fp, "foo"), 1:6)
+            @test length(s3_list_versions(fp.config, fp.bucket, fp.key)) == 6
+            s3_delete_all_versions(fp)
+            @test length(s3_list_versions(fp.config, fp.bucket, fp.key)) == 0
+            @test !exists(fp)
         end
 
         @testset "S3Path null version" begin

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -699,7 +699,7 @@ function s3path_tests(base_config)
             @test !exists(versioned_path)
             @test length(s3_list_versions(config, bucket_name, key)) == 1
 
-            fp = S3Path(config, bucket_name, "test_versions_deleteall")
+            fp = S3Path(bucket_name, "test_versions_deleteall"; config)
             foreach(_ -> write(fp, "foo"), 1:6)
             @test length(s3_list_versions(fp.config, fp.bucket, fp.key)) == 6
             s3_nuke_object_versions(fp)

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -702,7 +702,7 @@ function s3path_tests(base_config)
             fp = S3Path(config, bucket_name, "test_versions_deleteall")
             foreach(_ -> write(fp, "foo"), 1:6)
             @test length(s3_list_versions(fp.config, fp.bucket, fp.key)) == 6
-            s3_delete_all_versions(fp)
+            s3_nuke_object_versions(fp)
             @test length(s3_list_versions(fp.config, fp.bucket, fp.key)) == 0
             @test !exists(fp)
         end

--- a/test/s3path.jl
+++ b/test/s3path.jl
@@ -702,7 +702,7 @@ function s3path_tests(base_config)
             fp = S3Path(bucket_name, "test_versions_deleteall"; config)
             foreach(_ -> write(fp, "foo"), 1:6)
             @test length(s3_list_versions(fp.config, fp.bucket, fp.key)) == 6
-            s3_nuke_object_versions(fp)
+            s3_nuke_object(fp)
             @test length(s3_list_versions(fp.config, fp.bucket, fp.key)) == 0
             @test !exists(fp)
         end


### PR DESCRIPTION
The existing `s3_delete` allows the deletion of either the most recent or a specific, specified version of an object; this new ~`s3_delete_all_versions`~ `s3_nuke_object` deletes _all_ versions of that object.

Upstreamed from internal code originally written by @kleinschmidt 