### PR TITLE
Add `return_parsed` kwarg to `s3_copy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 - v0.11.0: The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
 - v0.11.1: The new keyword argument `returns` for `Base.write(fp::S3Path, ...)` determines the output returned from `write`, which can now be the raw `AWS.Response` (`returns=:response`) or the `S3Path` (`returns=:path`); this latter option returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#293]).
-- v0.11.2: TODO
+- v0.11.2: The new function `versioned_s3_copy` returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#300]).
 
 [#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289
 [#293]: https://github.com/JuliaCloud/AWSS3.jl/pull/293
+[#300]: https://github.com/JuliaCloud/AWSS3.jl/pull/300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
-# AWSS3.jl v0.11.0 Release Notes
+# AWSS3.jl v0.11 Release Notes
 
 ## Breaking changes
 
-- The `s3_exists`, `isdir(::S3Path)`, and `isfile(::S3Path)` calls now specify the `delimiter` to be `"/"` instead of `""` to support IAM policies which allow limited access to specified prefixes (see this [example](https://github.com/JuliaCloud/AWSS3.jl/pull/289#discussion_r1224636214)). Users who previously used the IAM policies conditional `{"Condition":{"StringEquals":{"s3:delimiter":[""]}}}` with AWSS3.jl v0.10 will need to update their IAM policy to be `{"s3:delimiter":["/"]}` with AWSS3.jl v0.11.0. To maintain compatibility with both versions of AWSS3.jl use the policy `{"s3:delimiter":["","/"]}`. Any policies not using the conditional `s3:delimiter` are unaffected ([#289]).
+- v0.11.0: The `s3_exists`, `isdir(::S3Path)`, and `isfile(::S3Path)` calls now specify the `delimiter` to be `"/"` instead of `""` to support IAM policies which allow limited access to specified prefixes (see this [example](https://github.com/JuliaCloud/AWSS3.jl/pull/289#discussion_r1224636214)). Users who previously used the IAM policies conditional `{"Condition":{"StringEquals":{"s3:delimiter":[""]}}}` with AWSS3.jl v0.10 will need to update their IAM policy to be `{"s3:delimiter":["/"]}` with AWSS3.jl v0.11.0. To maintain compatibility with both versions of AWSS3.jl use the policy `{"s3:delimiter":["","/"]}`. Any policies not using the conditional `s3:delimiter` are unaffected ([#289]).
 
 ## Non-breaking changes
 
-- The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
+- v0.11.0: The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
+- v0.11.1: The new keyword argument `returns` for `Base.write(fp::S3Path, ...)` determines the output returned from `write`, which can now be the raw `AWS.Response` (`returns=:response`) or the `S3Path` (`returns=:path`); this latter option returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#293]).
 
 [#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289
+[#293]: https://github.com/JuliaCloud/AWSS3.jl/pull/293

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - v0.11.0: The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
 - v0.11.1: The new keyword argument `returns` for `Base.write(fp::S3Path, ...)` determines the output returned from `write`, which can now be the raw `AWS.Response` (`returns=:response`) or the `S3Path` (`returns=:path`); this latter option returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#293]).
-- v0.11.2: The new keyword argument `parse_response` for `s3_copy` enables, e.g., accessing the version ID of a copied object (when versioning is enabled on the bucket) ([#300]).
+- v0.11.2: `s3_copy` supports the `parse_response` keyword allowing for access to the unparsed AWS API response ([#300]).
 
 [#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289
 [#293]: https://github.com/JuliaCloud/AWSS3.jl/pull/293

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - v0.11.0: The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
 - v0.11.1: The new keyword argument `returns` for `Base.write(fp::S3Path, ...)` determines the output returned from `write`, which can now be the raw `AWS.Response` (`returns=:response`) or the `S3Path` (`returns=:path`); this latter option returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#293]).
+- v0.11.2: TODO
 
 [#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289
 [#293]: https://github.com/JuliaCloud/AWSS3.jl/pull/293

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - v0.11.0: The `s3_exists` and `isdir(::S3Path)` calls no longer encounter HTTP 403 (Access Denied) errors when attempting to list resources which requiring an `s3:prefix` to be specified ([#289]).
 - v0.11.1: The new keyword argument `returns` for `Base.write(fp::S3Path, ...)` determines the output returned from `write`, which can now be the raw `AWS.Response` (`returns=:response`) or the `S3Path` (`returns=:path`); this latter option returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#293]).
-- v0.11.2: The new function `versioned_s3_copy` returns an `S3Path` populated with the version ID of the written object (when versioning is enabled on the bucket) ([#300]).
+- v0.11.2: The new keyword argument `parse_response` for `s3_copy` enables, e.g., accessing the version ID of a copied object (when versioning is enabled on the bucket) ([#300]).
 
 [#289]: https://github.com/JuliaCloud/AWSS3.jl/pull/289
 [#293]: https://github.com/JuliaCloud/AWSS3.jl/pull/293

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -411,14 +411,27 @@ end
 s3_delete(a...; b...) = s3_delete(global_aws_config(), a...; b...)
 
 """
-    s3_copy([::AbstractAWSConfig], bucket, path; to_bucket=bucket, to_path=path,
+    s3_copy([::AbstractAWSConfig], bucket, path; acl::AbstractString="",
+            to_bucket=bucket, to_path=path, metadata::AbstractDict=SSDict(),
             parse_response::Bool=true, kwargs...)
 
-[PUT Object - Copy](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html)
+Copy the object at `path` in `bucket` to `to_path` in `to_bucket`.
 
 # Optional Arguments
-- `metadata::Dict=`; optional `x-amz-meta-` headers.
+- `acl=`; `x-amz-acl` header for setting access permissions with canned config.
+    See [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
+- `metadata::Dict=`; `x-amz-meta-` headers.
 - `parse_response::Bool=`; when `false`, return raw `AWS.Response`
+- `kwargs`; additional kwargs passed through into `S3.copy_object`
+
+# API Calls
+
+- [`CopyObject`](http://https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html)
+
+# Permissions
+
+- [`s3:PutObject`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-PutObject)
+- [`s3:GetObject`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-GetObject)
 """
 function s3_copy(
     aws::AbstractAWSConfig,

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -454,34 +454,6 @@ end
 s3_copy(a...; b...) = s3_copy(global_aws_config(), a...; b...)
 
 """
-    versioned_s3_copy([::AbstractAWSConfig], bucket, path; to_bucket=bucket,
-                      to_path=path, kwargs...)
-
-Return destination `S3Path` from calling [`s3_copy`](@ref), with same input args
-and kwargs. When `to_bucket` has versioning enabled, output includes version of
-destination object.
-"""
-function versioned_s3_copy(
-    aws::AbstractAWSConfig,
-    bucket,
-    path;
-    to_bucket=bucket,
-    to_path=path,
-    metadata::AbstractDict=SSDict(),
-    kwargs...,
-)
-    response = s3_copy(
-        aws, bucket, path;parse_response=false, to_bucket, to_path, metadata,  kwargs...
-    )
-    return S3Path(
-        to_bucket,
-        to_path;
-        version=HTTP.header(response.headers, "x-amz-version-id", nothing),
-        config=aws,
-    )
-end
-
-"""
     s3_create_bucket([::AbstractAWSConfig], bucket; kwargs...)
 
 Creates a new S3 bucket with the globally unique `bucket` name. The bucket will be created

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -97,8 +97,12 @@ function awss3_tests(base_config)
 
     @testset "Object Copy" begin
         config = assume_testset_role("ReadWriteObject"; base_config)
-        s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy")
+        @test s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy") == UInt8[]
         @test s3_get(config, bucket_name, "key1.copy") == b"data1.v1"
+
+        result = s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy", parse_response=false)
+        @test result isa AWS.Response
+        @test !isnothing(HTTP.header(response.headers, "x-amz-version-id", nothing))
     end
 
     @testset "Object exists" begin

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -100,7 +100,7 @@ function awss3_tests(base_config)
         result = s3_copy(
             config, bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy"
         )
-        @test isa(result, LittleDict)
+        @test result isa AbstractDict
         @test s3_get(config, bucket_name, "key1.copy") == b"data1.v1"
 
         result = s3_copy(

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -113,7 +113,10 @@ function awss3_tests(base_config)
             parse_response=false,
         )
         @test result isa AWS.Response
-        @test !isnothing(HTTP.header(result.headers, "x-amz-version-id", nothing))
+
+        if is_aws(base_config)
+            @test !isnothing(HTTP.header(result.headers, "x-amz-version-id", nothing))
+        end
     end
 
     @testset "Object exists" begin

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -97,12 +97,16 @@ function awss3_tests(base_config)
 
     @testset "Object Copy" begin
         config = assume_testset_role("ReadWriteObject"; base_config)
-        result = s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy")
+        result = s3_copy(
+            config, bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy"
+        )
         @test isa(result, LittleDict)
         @test s3_get(config, bucket_name, "key1.copy") == b"data1.v1"
 
         result = s3_copy(
+            config,
             bucket_name,
+            key;
             "key1";
             to_bucket=bucket_name,
             to_path="key1.copy",

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -97,8 +97,8 @@ function awss3_tests(base_config)
 
     @testset "Object Copy" begin
         config = assume_testset_role("ReadWriteObject"; base_config)
-        @test s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy") ==
-            UInt8[]
+        result = s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy")
+        @test isa(result, LittleDict)
         @test s3_get(config, bucket_name, "key1.copy") == b"data1.v1"
 
         result = s3_copy(
@@ -109,7 +109,7 @@ function awss3_tests(base_config)
             parse_response=false,
         )
         @test result isa AWS.Response
-        @test !isnothing(HTTP.header(response.headers, "x-amz-version-id", nothing))
+        @test !isnothing(HTTP.header(result.headers, "x-amz-version-id", nothing))
     end
 
     @testset "Object exists" begin

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -106,7 +106,6 @@ function awss3_tests(base_config)
         result = s3_copy(
             config,
             bucket_name,
-            key;
             "key1";
             to_bucket=bucket_name,
             to_path="key1.copy",

--- a/test/awss3.jl
+++ b/test/awss3.jl
@@ -97,10 +97,17 @@ function awss3_tests(base_config)
 
     @testset "Object Copy" begin
         config = assume_testset_role("ReadWriteObject"; base_config)
-        @test s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy") == UInt8[]
+        @test s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy") ==
+            UInt8[]
         @test s3_get(config, bucket_name, "key1.copy") == b"data1.v1"
 
-        result = s3_copy(bucket_name, "key1"; to_bucket=bucket_name, to_path="key1.copy", parse_response=false)
+        result = s3_copy(
+            bucket_name,
+            "key1";
+            to_bucket=bucket_name,
+            to_path="key1.copy",
+            parse_response=false,
+        )
         @test result isa AWS.Response
         @test !isnothing(HTTP.header(response.headers, "x-amz-version-id", nothing))
     end


### PR DESCRIPTION
Add `return_parsed` kwarg (default `true` to be non-breaking) to `s3_copy`.

Related to #293.