### PR TITLE
Remove versions from request to `list_object_versions`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSS3"
 uuid = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-version = "0.11.2"
+version = "0.11.3"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/AWSS3.jl
+++ b/src/AWSS3.jl
@@ -898,7 +898,7 @@ function s3_list_versions(aws::AbstractAWSConfig, bucket, path_prefix=""; kwargs
     marker = ""
 
     while more
-        query = Dict{String,Any}("versions" => "", "prefix" => path_prefix)
+        query = Dict{String,Any}("prefix" => path_prefix)
 
         if !isempty(marker)
             query["key-marker"] = marker


### PR DESCRIPTION
When using AWSS3.jl's `s3_list_versions` function we were suddenly seeing the error `SignatureDoesNotMatch`:

```
ERROR: AWS.AWSExceptions.AWSException: SignatureDoesNotMatch -- The request signature we calculated does not match the signature you provided. Check your key and signing method.
```

We reproduced the problem and discovered making successful S3 API call before a call `s3_list_versions` would allow it to work successfully (due to HTTP.jl's use of connection pooling). We eventually identified that the HTTP query parameter versions was set both [in AWSS3.jl](https://github.com/JuliaCloud/AWSS3.jl/blob/20523698a5fe062b538be4e1a1c89ae90423b433/src/AWSS3.jl#L901) and [in AWS.jl](https://github.com/JuliaCloud/AWS.jl/blob/3ae57206145dd0094847082204dc3392fe302d5d/src/services/s3.jl#L4649) which caused the parameter to be included in the URI twice. When AWS.jl computes the signature it removes duplicate query keys but it appears that the AWS API backend does not. Removing versions from AWSS3.jl fixes the issue and we will make a PR to AWS.jl to avoid removing duplicate query keys when calculating the signature (the logic here is that if the request includes the duplicates then so should the signature).