### PR TITLE
Using a GitHub merge queue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,17 +1,17 @@
 name: CI
-# Run on master, any tag or any pull request
 on:
+  merge_group:
+  pull_request:
   push:
     branches:
       - master
-      - staging
-      - trying
     tags: '*'
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    if: ${{ github.event_name != 'pull_request' }}
     permissions:
       # Required for interacting with GitHub's OIDC Token endpoint:
       # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-permissions-settings
@@ -59,6 +59,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates the repository workflow to use GitHub merge queues as the replacement for Bors (which has been [phased out](https://bors.tech/documentation/getting-started/)). The CI workflows which are tested against an actual AWS account are now only run when a PR enters the merge queue. Only if the PR passes the checks will the PR be actually merged. We use this setup as it avoids having contributors execute arbitrary code in this AWS environment.

Closes: https://github.com/JuliaCloud/AWSS3.jl/issues/309